### PR TITLE
Refine public content presentation and notifications

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,7 @@ The current build is meant to be a practical, low-overhead publishing and coordi
 ## Longer Term
 
 - Add transparent page editing for static pages such as Home and About. The intended workflow is a keyboard shortcut (`Ctrl+Shift+E`) that reveals a fixed bottom control bar with revert, undo, redo, and save actions while the page itself is edited in place. This editing mode is meant for queued snapshot-to-GitHub bakedown, not synchronized live co-editing.
+- Add image handling inside the document editor, including attachment, placement controls (left, right, full width), and markdown-safe storage through the existing blob workflow.
 - Add stronger map and archive views as the entity and location dataset grows.
 - Improve collaboration tools for volunteers, including clearer review states and richer discussion around submissions.
 - Package the reusable parts of the system so future campaign sites can launch with less custom setup.

--- a/about.html
+++ b/about.html
@@ -56,24 +56,23 @@
       </section>
 
       <section class="section">
-        <div class="wrap page-layout">
-          <div class="surface-panel">
+        <div class="wrap support-grid support-grid--duo">
+          <div class="surface-panel surface-panel--stacked">
             <div class="eyebrow">Editorial posture</div>
             <h2>Credible, plain, and evidence-first.</h2>
             <p>The project aims to keep the tone plain and evidence-first: enough context to orient readers, enough documentation to support scrutiny, and enough clarity for others to build on the work.</p>
             <p>This page can also hold future background on collaborators, media contact details, or a longer statement of purpose if that becomes useful.</p>
           </div>
-
-          <aside class="surface-panel surface-panel--dark">
-            <div class="eyebrow">Related pages</div>
-            <h3>Where visitors go next</h3>
-            <p>Most readers should funnel from this page into the investigations archive, the guide, or the support page. Social and content links belong here too, not in the merch flow.</p>
+          <section class="surface-panel surface-panel--stacked">
+            <div class="eyebrow">Dive in</div>
+            <h2>See what the project is building.</h2>
+            <p>Move from this overview into the investigations archive, the public guide, or the project’s video updates.</p>
             <div class="button-row">
               <a class="button" href="./investigations.html">Read investigations</a>
-              <a class="button-ghost" data-youtube-link href="https://youtube.com/@truecostproject" target="_blank" rel="noopener noreferrer">Visit YouTube</a>
               <a class="button-ghost" href="./guide.html">Read the guide</a>
+              <a class="button-ghost" data-youtube-link href="https://youtube.com/@truecostproject" target="_blank" rel="noopener noreferrer">Visit YouTube</a>
             </div>
-          </aside>
+          </section>
         </div>
       </section>
     </main>

--- a/get-involved.html
+++ b/get-involved.html
@@ -37,19 +37,19 @@
 
       <section class="section">
         <div class="wrap card-grid">
-          <article class="surface-panel">
+          <article class="surface-panel surface-panel--stacked">
             <div class="eyebrow">Donate</div>
             <h3>Fund records fees and reporting time</h3>
             <p>Donations can support records requests, document review, travel, and the time required to turn raw material into public investigations.</p>
             <a class="button" data-donate-link href="https://example.org/donate">Donate</a>
           </article>
-          <article class="surface-panel">
+          <article class="surface-panel surface-panel--stacked">
             <div class="eyebrow">Collaborate</div>
             <h3>Bring research skills or local knowledge</h3>
             <p>Local context, document sorting, note-taking, and public-records experience can all strengthen the work.</p>
             <a class="button-ghost" href="./submit.html">Send a lead</a>
           </article>
-          <article class="surface-panel">
+          <article class="surface-panel surface-panel--stacked">
             <div class="eyebrow">Share</div>
             <h3>Extend the reach of each case file</h3>
             <p>Sharing published investigations, source material, and related reporting helps the archive travel further.</p>
@@ -59,8 +59,8 @@
       </section>
 
       <section class="section">
-        <div class="wrap page-layout">
-          <div class="surface-panel">
+        <div class="wrap support-grid support-grid--duo">
+          <div class="surface-panel surface-panel--stacked">
             <div class="eyebrow">Support</div>
             <h2>Keep the ask direct.</h2>
             <div class="support-grid">
@@ -78,13 +78,14 @@
               </article>
             </div>
           </div>
-
-          <aside class="surface-panel surface-panel--dark">
+          <section class="surface-panel surface-panel--stacked">
             <div class="eyebrow">Contact</div>
-            <h3>Collaboration channel</h3>
-            <p>Use a direct email link here, or swap this panel for a volunteer intake form later if the project wants a more structured collaborator workflow.</p>
-            <a class="text-link" data-contact-email href="mailto:tips@example.org"></a>
-          </aside>
+            <h2>Email the project directly.</h2>
+            <p>If you want to collaborate, ask a question, or offer help, send a note directly and the project can follow up from there.</p>
+            <div class="button-row">
+              <a class="button" data-contact-email href="mailto:tips@example.org"></a>
+            </div>
+          </section>
         </div>
       </section>
     </main>

--- a/guide.html
+++ b/guide.html
@@ -37,7 +37,7 @@
 
       <section class="section">
         <div class="wrap page-layout">
-          <article class="article-shell hero__panel" data-markdown-article data-markdown-src="./content/pages/guide.md"></article>
+          <article class="article-shell surface-panel article-shell--light" data-markdown-article data-markdown-src="./content/pages/guide.md"></article>
           <aside class="article-aside">
             <section class="surface-panel">
               <div class="eyebrow">On this page</div>

--- a/index.html
+++ b/index.html
@@ -29,61 +29,17 @@
   <div class="page-shell">
     <main>
       <section class="hero hero--home">
-        <div class="wrap hero__grid">
+        <div class="wrap">
           <div class="hero__copy">
             <div class="eyebrow">Public records. Public money. Public accountability.</div>
             <h1>Follow the money behind animal agriculture.</h1>
-            <p class="hero__lede">The True Cost Project documents how taxpayer resources move into industrial animal agriculture, then turns those records into clear, public-facing investigations and tools others can use.</p>
+            <p class="hero__lede">The True Cost Project documents how taxpayer resources move into industrial animal agriculture, then turns those records into clear, public-facing investigations and practical tools others can use.</p>
             <div class="hero__actions">
               <a class="button" href="./investigations.html">Read investigations</a>
               <a class="button-ghost" href="./guide.html">Learn the method</a>
               <a class="button-dark" href="./submit.html">Submit a tip</a>
             </div>
           </div>
-
-          <aside class="hero__panel">
-            <div class="hero__panel-top">
-              <div>
-                <div class="eyebrow">What you will find here</div>
-                <h3>Investigations, guidance, and ways to contribute</h3>
-              </div>
-              <small class="muted">Public archive</small>
-            </div>
-            <div class="hero__panel-body">
-              <p>The site is built to publish investigations cleanly, organize related places and entities, and make participation straightforward for people who want to contribute records or research.</p>
-              <ul class="hero__evidence">
-                <li>
-                  <strong>Case files</strong>
-                  <small>Published investigations with tags, supporting notes, and linked source material.</small>
-                </li>
-                <li>
-                  <strong>Practical guidance</strong>
-                  <small>A guide for records requests, basic research steps, and documenting findings.</small>
-                </li>
-                <li>
-                  <strong>Participation</strong>
-                  <small>Submission tools, collaboration routes, and support options.</small>
-                </li>
-              </ul>
-            </div>
-          </aside>
-        </div>
-      </section>
-
-      <section class="section">
-        <div class="wrap metric-grid">
-          <article class="metric-card">
-            <strong>3</strong>
-            <p>Sample investigations showing the archive layout, tags, and supporting-note structure.</p>
-          </article>
-          <article class="metric-card">
-            <strong>1</strong>
-            <p>Guide page outlining how research and records work can be documented and shared.</p>
-          </article>
-          <article class="metric-card">
-            <strong>Map-ready</strong>
-            <p>Entity entries can connect investigations to a geographic index without turning the site into a heavy CMS.</p>
-          </article>
         </div>
       </section>
 
@@ -126,23 +82,17 @@
       </section>
 
       <section class="section">
-        <div class="wrap page-layout">
+        <div class="wrap">
           <div class="surface-panel">
             <div class="eyebrow">Get involved</div>
             <h2>Help expand the work.</h2>
-            <p>People can support the project by sharing leads, passing along documents, offering research help, or helping sustain the records work financially.</p>
+            <p>Support can mean sharing leads, passing along documents, helping with research, or sustaining the records work financially.</p>
             <div class="button-row">
               <a class="button" href="./get-involved.html">Get involved</a>
               <a class="button-ghost" href="./submit.html">Submit material</a>
+              <a class="button-ghost" href="./map.html">Browse the map</a>
             </div>
           </div>
-
-          <aside class="surface-panel surface-panel--dark">
-            <div class="eyebrow">Explore</div>
-            <h3>Use the archive in different ways</h3>
-            <p>Readers can move through the site by investigation, by guide, or by map as the archive grows.</p>
-            <a class="text-link" href="./map.html">Open the map</a>
-          </aside>
         </div>
       </section>
 

--- a/investigation.html
+++ b/investigation.html
@@ -38,35 +38,13 @@
       </section>
 
       <section class="section">
-        <div class="wrap page-layout">
-          <article class="article-shell hero__panel" data-investigation-article></article>
-
-          <aside class="article-aside">
-            <section class="surface-panel">
-              <div class="eyebrow">Case metadata</div>
-              <div class="meta-list">
-                <div>
-                  <strong>Published</strong>
-                  <span data-investigation-date></span>
-                </div>
-                <div>
-                  <strong>Location</strong>
-                  <span data-investigation-region></span>
-                </div>
-                <div>
-                  <strong>Status</strong>
-                  <span data-investigation-status></span>
-                </div>
-              </div>
-            </section>
-
-            <section class="surface-panel" data-investigation-review hidden></section>
-
-            <section class="surface-panel">
-              <div class="eyebrow">Structured notes</div>
-              <div class="record-list" data-investigation-records></div>
-            </section>
-          </aside>
+        <div class="wrap article-stack">
+          <p class="article-inline-meta" data-investigation-meta></p>
+          <article class="article-shell surface-panel article-shell--light" data-investigation-article></article>
+          <section class="surface-panel article-notes-panel" data-investigation-records-shell hidden>
+            <div class="eyebrow">Structured notes</div>
+            <div class="record-list" data-investigation-records></div>
+          </section>
         </div>
       </section>
 

--- a/merch.html
+++ b/merch.html
@@ -36,21 +36,24 @@
       </section>
 
       <section class="section">
-        <div class="wrap page-layout">
-          <div class="surface-panel">
+        <div class="wrap support-grid support-grid--duo">
+          <div class="surface-panel surface-panel--stacked">
             <div class="eyebrow">Store link</div>
             <h2>External merchandise store</h2>
-            <p>Keep the on-site copy minimal: explain where the store lives, what merch supports, and how that support connects back to the investigations.</p>
+            <p>Keep the on-site copy minimal: explain where the store lives and what merch support helps fund.</p>
             <div class="button-row">
               <a class="button" data-merch-link href="https://example.org/store" target="_blank" rel="noopener noreferrer">Open merch store</a>
             </div>
           </div>
-
-          <aside class="surface-panel surface-panel--dark">
-            <div class="eyebrow">Why it stays simple</div>
-            <h3>No reason to duplicate storefront work</h3>
-            <p>GitHub Pages handles the site. The external merch platform handles checkout, fulfillment, taxes, and inventory. That keeps maintenance low.</p>
-          </aside>
+          <section class="surface-panel surface-panel--stacked">
+            <div class="eyebrow">Keep exploring</div>
+            <h2>Follow the work behind the project.</h2>
+            <p>After the store, the best next stop is usually the investigations archive or the project’s latest video updates.</p>
+            <div class="button-row">
+              <a class="button-ghost" href="./investigations.html">Browse investigations</a>
+              <a class="button-ghost" data-youtube-link href="https://youtube.com/@truecostproject" target="_blank" rel="noopener noreferrer">Visit YouTube</a>
+            </div>
+          </section>
         </div>
       </section>
     </main>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -106,8 +106,20 @@ function initNavigation() {
       if (menu) {
         const isOpen = !menu.classList.contains("is-open");
         menu.classList.toggle("is-open", isOpen);
-        if (isOpen) markNotificationsSeen();
       }
+      return;
+    }
+
+    if (target.closest("[data-clear-notifications]")) {
+      event.preventDefault();
+      clearNotifications();
+      renderNavigation();
+      return;
+    }
+
+    const notificationLink = target.closest("[data-notification-link]");
+    if (notificationLink) {
+      dismissNotification(notificationLink.getAttribute("data-notification-link") || "");
       return;
     }
 
@@ -173,7 +185,7 @@ function renderNavigation() {
       state.publicState?.admins?.includes(state.viewer.pubkey)
   );
   const notifications = isLoggedIn ? state.notifications.slice(0, 8) : [];
-  const unreadCount = isLoggedIn ? countUnreadNotifications(notifications) : 0;
+  const unreadCount = isLoggedIn ? notifications.length : 0;
   const mapEnabled = Boolean(state.publicState?.connected);
   const mapCurrent = NAV_KEYS.map.includes(page);
 
@@ -216,20 +228,27 @@ function renderNavigation() {
         ${
           isLoggedIn
             ? `
-              ${
-                state.notificationsLoading
-                  ? `<div class="profile-menu__section"><div class="loading-state" role="status" aria-live="polite"><span class="loading-spinner" aria-hidden="true"></span><span>Looking up notifications...</span></div></div>`
-                  : notifications.length
-                    ? `
-                      <div class="profile-menu__section">
-                        <div class="profile-menu__section-title">Notifications</div>
-                        <div class="profile-menu__notifications">
-                          ${notifications.map((item) => renderNotificationItem(item)).join("")}
-                        </div>
-                      </div>
-                    `
-                    : ""
-              }
+              <div class="profile-menu__section">
+                <div class="profile-menu__section-title">Notifications</div>
+                <div class="profile-menu__notification-shell">
+                  <div class="profile-menu__notification-head">
+                    <span>Notifications</span>
+                    ${unreadCount ? `<span class="profile-menu__inline-badge">${Math.min(unreadCount, 9)}${unreadCount > 9 ? "+" : ""}</span>` : `<span class="profile-menu__inline-badge is-muted">0</span>`}
+                  </div>
+                  ${
+                    state.notificationsLoading
+                      ? `<div class="loading-state" role="status" aria-live="polite"><span class="loading-spinner" aria-hidden="true"></span><span>Looking up notifications...</span></div>`
+                      : notifications.length
+                        ? `
+                          <div class="profile-menu__notifications">
+                            ${notifications.map((item) => renderNotificationItem(item)).join("")}
+                          </div>
+                          <button class="profile-menu__clear" type="button" data-clear-notifications>Clear notifications</button>
+                        `
+                        : `<div class="profile-menu__notification-empty">No notifications right now.</div>`
+                  }
+                </div>
+              </div>
               <a href="./admin.html?tab=profile">Profile options</a>
               ${isAdmin ? `<a href="./admin.html?tab=dashboard">Admin</a>` : ""}
               <button type="button" data-signout>Sign out</button>
@@ -335,7 +354,7 @@ async function initInvestigationDetail() {
   if (!article) return;
   article.innerHTML = renderLoadingState("Looking up article...");
   const commentPanel = document.querySelector("[data-comment-panel]");
-  const reviewPanel = document.querySelector("[data-investigation-review]");
+  const recordsShell = document.querySelector("[data-investigation-records-shell]");
   if (commentPanel) commentPanel.innerHTML = renderLoadingState("Looking up discussion...");
 
   try {
@@ -360,13 +379,15 @@ async function initInvestigationDetail() {
     renderMarkdown(article, post.body);
     setText("[data-investigation-title]", post.title);
     setText("[data-investigation-summary]", post.summary);
-    setText("[data-investigation-date]", formatDate(post.date));
-    setText("[data-investigation-region]", post.location);
-    setText("[data-investigation-status]", post.statusLabel || post.status);
+    setText("[data-investigation-meta]", buildArticleMetaLine(post));
     const tags = document.querySelector("[data-investigation-kicker]");
     if (tags) tags.innerHTML = renderTagList(post.tags);
     const records = document.querySelector("[data-investigation-records]");
-    if (records) records.innerHTML = renderRecordList(post.records);
+    if (records) {
+      const hasRecords = Array.isArray(post.records) && post.records.length;
+      records.innerHTML = renderRecordList(post.records);
+      if (recordsShell instanceof HTMLElement) recordsShell.hidden = !hasRecords;
+    }
     const related = document.querySelector("[data-investigation-related]");
     if (related) {
       related.innerHTML = isDraftPreview
@@ -379,14 +400,20 @@ async function initInvestigationDetail() {
     }
 
     enrichArticleEntities(article, publicState);
-    if (reviewPanel instanceof HTMLElement) {
+    let reviewShell = document.querySelector("[data-investigation-review-shell]");
+    if (isDraftPreview && !(reviewShell instanceof HTMLElement)) {
+      reviewShell = document.createElement("section");
+      reviewShell.className = "surface-panel article-review-panel";
+      reviewShell.setAttribute("data-investigation-review-shell", "");
+      article.insertAdjacentElement("afterend", reviewShell);
+    }
+    if (reviewShell instanceof HTMLElement) {
       if (isDraftPreview) {
-        reviewPanel.hidden = false;
-        reviewPanel.innerHTML = renderReviewPreviewPanel(draft);
-        bindReviewPreviewPanel(reviewPanel, draft);
+        reviewShell.hidden = false;
+        reviewShell.innerHTML = renderReviewPreviewPanel(draft);
+        bindReviewPreviewPanel(reviewShell, draft);
       } else {
-        reviewPanel.hidden = true;
-        reviewPanel.innerHTML = "";
+        reviewShell.remove();
       }
     }
     if (commentPanel instanceof HTMLElement) {
@@ -400,10 +427,11 @@ async function initInvestigationDetail() {
     document.title = `${post.title} | ${SITE.shortName}`;
   } catch {
     renderError(article, "This case file could not be loaded.");
-    if (reviewPanel instanceof HTMLElement) {
-      reviewPanel.hidden = true;
-      reviewPanel.innerHTML = "";
+    const reviewShell = document.querySelector("[data-investigation-review-shell]");
+    if (reviewShell instanceof HTMLElement) {
+      reviewShell.remove();
     }
+    if (recordsShell instanceof HTMLElement) recordsShell.hidden = true;
   }
 }
 
@@ -1059,7 +1087,6 @@ async function buildNotifications(publicState) {
   const viewer = state.viewer;
   if (!viewer) return [];
   const notifications = [];
-  const seenAt = notificationSeenAt();
   const isAdmin = publicState.admins?.includes(viewer.pubkey);
   const commentMap = new Map((publicState.allComments || []).map((comment) => [comment.id, comment]));
 
@@ -1071,7 +1098,6 @@ async function buildNotifications(publicState) {
       id: `comment-reply:${comment.id}`,
       createdAt: comment.created_at,
       href: `./investigation.html?slug=${encodeURIComponent(comment.post_slug)}#comment-${encodeURIComponent(comment.id)}`,
-      unread: comment.created_at > seenAt,
       label: "Comment reply",
       title: "Someone replied to your comment",
       detail: trimmed(comment.markdown, 100)
@@ -1084,7 +1110,6 @@ async function buildNotifications(publicState) {
       id: `submission-status:${status.submission_id}:${status.updated_at}`,
       createdAt: status.updated_at,
       href: "./submit.html",
-      unread: status.updated_at > seenAt,
       label: "Submission update",
       title: `Submission ${status.status}`,
       detail: status.note || "A submission you sent has a new status."
@@ -1102,7 +1127,6 @@ async function buildNotifications(publicState) {
         href: normalizeDraftStatus(draft.status) === "revision"
           ? `./editor.html?slug=${encodeURIComponent(draft.slug)}`
           : `./investigation.html?draft=${encodeURIComponent(draft.slug)}`,
-        unread: draft.created_at > seenAt,
         label: "Investigation review",
         title: reviewNotificationTitle(reviewAction),
         detail: draft.title
@@ -1113,7 +1137,6 @@ async function buildNotifications(publicState) {
         id: `pending-draft:${draft.slug}:${draft.created_at}`,
         createdAt: draft.created_at,
         href: `./investigation.html?draft=${encodeURIComponent(draft.slug)}`,
-        unread: draft.created_at > seenAt,
         label: "Review queue",
         title: "New investigation pending review",
         detail: draft.title
@@ -1128,7 +1151,6 @@ async function buildNotifications(publicState) {
         id: `post-comment:${comment.id}`,
         createdAt: comment.created_at,
         href: `./investigation.html?slug=${encodeURIComponent(comment.post_slug)}#comment-${encodeURIComponent(comment.id)}`,
-        unread: comment.created_at > seenAt,
         label: "Post reply",
         title: "New comment on a published investigation",
         detail: trimmed(comment.markdown, 100)
@@ -1137,14 +1159,14 @@ async function buildNotifications(publicState) {
   }
 
   const submissionNotifications = await loadSubmissionNotifications(publicState, viewer.pubkey, isAdmin);
-  notifications.push(...submissionNotifications.map((item) => ({
-    ...item,
-    unread: item.createdAt > seenAt
-  })));
+  notifications.push(...submissionNotifications);
+
+  const dismissed = dismissedNotificationIds();
 
   return notifications
     .sort((left, right) => right.createdAt - left.createdAt)
     .filter((item, index, items) => items.findIndex((candidate) => candidate.id === item.id) === index)
+    .filter((item) => !dismissed.has(item.id))
     .slice(0, 12);
 }
 
@@ -1211,34 +1233,44 @@ function notificationSitePubkeys(publicState) {
   ]);
 }
 
-function notificationSeenAt() {
-  if (!state.viewer?.pubkey) return 0;
-  const raw = window.localStorage.getItem(notificationSeenKey(state.viewer.pubkey));
-  const value = Number(raw || 0);
-  return Number.isFinite(value) ? value : 0;
+function dismissedNotificationIds() {
+  if (!state.viewer?.pubkey) return new Set();
+  try {
+    const raw = window.localStorage.getItem(notificationDismissedKey(state.viewer.pubkey));
+    const parsed = raw ? JSON.parse(raw) : [];
+    return new Set(Array.isArray(parsed) ? parsed.map((item) => String(item || "").trim()).filter(Boolean) : []);
+  } catch {
+    return new Set();
+  }
 }
 
-function notificationSeenKey(pubkey) {
-  return `${SITE.nostr.storageNamespace}.notifications.seen.${pubkey}`;
+function notificationDismissedKey(pubkey) {
+  return `${SITE.nostr.storageNamespace}.notifications.dismissed.${pubkey}`;
 }
 
-function markNotificationsSeen() {
+function dismissNotification(id) {
+  if (!state.viewer?.pubkey || !id) return;
+  const dismissed = dismissedNotificationIds();
+  dismissed.add(String(id));
+  window.localStorage.setItem(notificationDismissedKey(state.viewer.pubkey), JSON.stringify([...dismissed]));
+  state.notifications = state.notifications.filter((item) => item.id !== id);
+}
+
+function clearNotifications() {
   if (!state.viewer?.pubkey || !state.notifications.length) return;
-  const latest = state.notifications.reduce((max, item) => Math.max(max, Number(item.createdAt || 0)), 0);
-  if (!latest) return;
-  window.localStorage.setItem(notificationSeenKey(state.viewer.pubkey), String(latest));
-  state.notifications = state.notifications.map((item) => ({ ...item, unread: false }));
-  const badge = document.querySelector(".profile-menu__notice");
-  if (badge) badge.remove();
+  const dismissed = dismissedNotificationIds();
+  for (const item of state.notifications) dismissed.add(item.id);
+  window.localStorage.setItem(notificationDismissedKey(state.viewer.pubkey), JSON.stringify([...dismissed]));
+  state.notifications = [];
 }
 
 function countUnreadNotifications(notifications) {
-  return (Array.isArray(notifications) ? notifications : []).filter((item) => item.unread).length;
+  return Array.isArray(notifications) ? notifications.length : 0;
 }
 
 function renderNotificationItem(item) {
   return `
-    <a class="profile-menu__notice-item" href="${escapeAttribute(item.href)}">
+    <a class="profile-menu__notice-item" href="${escapeAttribute(item.href)}" data-notification-link="${escapeAttribute(item.id)}">
       <span class="profile-menu__notice-label">${escapeHtml(item.label)}</span>
       <strong>${escapeHtml(item.title)}</strong>
       <span>${escapeHtml(item.detail || "")}</span>
@@ -1503,6 +1535,13 @@ function formatDateTime(unixSeconds) {
     hour: "numeric",
     minute: "2-digit"
   }).format(new Date(unixSeconds * 1000));
+}
+
+function buildArticleMetaLine(post) {
+  const parts = [formatDate(post.date)];
+  if (post.location) parts.push(String(post.location));
+  if (post.statusLabel || post.status) parts.push(String(post.statusLabel || post.status));
+  return parts.filter(Boolean).join(" · ");
 }
 
 function sortDateValue(item) {

--- a/styles.css
+++ b/styles.css
@@ -390,6 +390,9 @@ h3 {
 .profile-menu__notifications {
   display: grid;
   gap: 0.35rem;
+  max-height: 16rem;
+  overflow: auto;
+  padding-right: 0.2rem;
 }
 
 .profile-menu__notice-item {
@@ -413,6 +416,57 @@ h3 {
   text-transform: uppercase;
   font-family: "IBM Plex Mono", monospace;
   color: var(--accent);
+}
+
+.profile-menu__notification-shell {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.75rem;
+  border-radius: 16px;
+  background: rgba(18, 18, 18, 0.04);
+}
+
+.profile-menu__notification-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.profile-menu__inline-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 0.45rem;
+  border-radius: 999px;
+  background: rgba(156, 29, 24, 0.12);
+  color: var(--accent-deep);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.profile-menu__inline-badge.is-muted {
+  background: rgba(18, 18, 18, 0.08);
+  color: var(--ink-soft);
+}
+
+.profile-menu__clear {
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+
+.profile-menu__notification-empty {
+  color: var(--ink-soft);
+  font-size: 0.92rem;
 }
 
 .draft-note {
@@ -631,6 +685,15 @@ h3 {
   display: grid;
   gap: 0.8rem;
   padding: 1.45rem;
+}
+
+.surface-panel--stacked {
+  display: flex;
+  flex-direction: column;
+}
+
+.surface-panel--stacked .button-row {
+  margin-top: auto;
 }
 
 .investigation-card,
@@ -862,6 +925,21 @@ h3 {
 
 .page-layout > :only-child {
   grid-column: 1 / -1;
+}
+
+.article-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.article-inline-meta {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.94rem;
+}
+
+.support-grid--duo {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .article-shell {
@@ -1156,32 +1234,27 @@ h3 {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.45rem;
   border-bottom: 1px solid rgba(18, 18, 18, 0.08);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(243, 238, 231, 0.96));
-  padding: 0.95rem 1rem;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(248, 244, 238, 0.96));
+  padding: 0.8rem 0.9rem;
 }
 
 .editor-markdown-field .toastui-editor-toolbar-group {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin: 0;
-  padding-right: 0.75rem;
-  border-right: 1px solid rgba(18, 18, 18, 0.08);
-}
-
-.editor-markdown-field .toastui-editor-toolbar-group:last-child {
-  border-right: 0;
-  padding-right: 0;
+  gap: 0.4rem;
+  margin: 0 !important;
+  padding-right: 0 !important;
+  border-right: 0 !important;
 }
 
 .editor-markdown-field .toastui-editor-defaultUI-toolbar button {
   width: auto;
   min-width: 0;
-  height: 2.5rem;
+  height: 2.2rem;
   margin: 0;
-  padding: 0 0.9rem;
+  padding: 0 0.75rem;
 }
 
 .editor-markdown-field .toastui-editor-toolbar-icons,
@@ -1201,7 +1274,7 @@ h3 {
 .editor-markdown-field .toastui-editor-toolbar-icons::before,
 .editor-markdown-field .toastui-editor-toolbar-icons.last::before {
   content: attr(data-button-label);
-  font-size: 0.8rem;
+  font-size: 0.74rem;
   font-weight: 600;
   letter-spacing: 0.01em;
 }
@@ -1547,6 +1620,9 @@ h3 {
 .map-list {
   display: grid;
   gap: 1rem;
+  max-height: 36rem;
+  overflow: auto;
+  padding-right: 0.25rem;
 }
 
 .entity-card {


### PR DESCRIPTION
## Summary
- move notifications into a dedicated section inside the avatar menu instead of replacing the whole menu
- simplify article and page layouts so the public content reads cleanly and the empty review shell disappears
- reduce distracting panels, align CTA rows, and make the entity index scroll beside the map
- add the editor image-handling note to the roadmap

Closes #6