### PR TITLE
Tighten archive stats, map cards, and editor chrome

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,6 +19,7 @@ The current build is meant to be a practical, low-overhead publishing and coordi
 
 - Add transparent page editing for static pages such as Home and About. The intended workflow is a keyboard shortcut (`Ctrl+Shift+E`) that reveals a fixed bottom control bar with revert, undo, redo, and save actions while the page itself is edited in place. This editing mode is meant for queued snapshot-to-GitHub bakedown, not synchronized live co-editing.
 - Add image handling inside the document editor, including attachment, placement controls (left, right, full width), and markdown-safe storage through the existing blob workflow.
+- Add a navigable entity wiki that can enrich facilities, companies, agencies, and related records with expandable fields, history, and clearer cross-links into investigations and the map.
 - Add stronger map and archive views as the entity and location dataset grows.
 - Improve collaboration tools for volunteers, including clearer review states and richer discussion around submissions.
 - Package the reusable parts of the system so future campaign sites can launch with less custom setup.

--- a/about.html
+++ b/about.html
@@ -66,12 +66,8 @@
           <section class="surface-panel surface-panel--stacked">
             <div class="eyebrow">Dive in</div>
             <h2>See what the project is building.</h2>
-            <p>Move from this overview into the investigations archive, the public guide, or the project’s video updates.</p>
-            <div class="button-row">
-              <a class="button" href="./investigations.html">Read investigations</a>
-              <a class="button-ghost" href="./guide.html">Read the guide</a>
-              <a class="button-ghost" data-youtube-link href="https://youtube.com/@truecostproject" target="_blank" rel="noopener noreferrer">Visit YouTube</a>
-            </div>
+            <p>Move from this overview into the archive, the entity index, or the geographic view of the work.</p>
+            <div class="hero-summary hero-summary--light hero-summary--stack" data-archive-summary></div>
           </section>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -43,31 +43,12 @@
           <aside class="hero__panel">
             <div class="hero__panel-top">
               <div>
-                <div class="eyebrow">Archive snapshot</div>
-                <h3>Start with the archive, then follow the entity trail.</h3>
+                <div class="eyebrow">Archive</div>
+                <h3>Explore a living archive.</h3>
               </div>
             </div>
             <div class="hero__panel-body">
-              <p>The archive, map, and guide should work together: published investigations, tracked locations, and a clear route into the reporting method.</p>
-              <div class="hero-summary" data-home-summary>
-                <div class="hero-summary__item">
-                  <strong>...</strong>
-                  <span>Published investigations</span>
-                </div>
-                <div class="hero-summary__item">
-                  <strong>...</strong>
-                  <span>Tracked entities</span>
-                </div>
-                <div class="hero-summary__item">
-                  <strong>...</strong>
-                  <span>Archive locations</span>
-                </div>
-              </div>
-              <div class="button-row">
-                <a class="button" href="./investigations.html">Open archive</a>
-                <a class="button-ghost" href="./map.html">Browse the map</a>
-                <a class="button-ghost" href="./guide.html">Read the guide</a>
-              </div>
+              <div class="hero-summary hero-summary--stack" data-archive-summary></div>
             </div>
           </aside>
         </div>

--- a/map.html
+++ b/map.html
@@ -38,12 +38,12 @@
 
       <section class="section">
         <div class="wrap map-shell">
-          <section class="surface-panel">
+          <section class="surface-panel" id="map-board">
             <div class="eyebrow">Locations</div>
             <div class="map-board map-board--leaflet" data-map-canvas></div>
           </section>
 
-          <section class="surface-panel">
+          <section class="surface-panel" id="entity-index">
             <div class="eyebrow">Entity index</div>
             <div class="map-list" data-map-list></div>
           </section>

--- a/merch.html
+++ b/merch.html
@@ -36,7 +36,7 @@
       </section>
 
       <section class="section">
-        <div class="wrap support-grid support-grid--duo">
+        <div class="wrap card-grid card-grid--duo">
           <div class="surface-panel surface-panel--stacked">
             <div class="eyebrow">Store link</div>
             <h2>External merchandise store</h2>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -52,7 +52,8 @@ const state = {
   archiveFilterOpenField: "",
   archiveFilterTimer: null,
   map: null,
-  markers: null
+  markers: null,
+  markerIndex: null
 };
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -365,7 +366,8 @@ async function initInvestigationCards() {
   const homeGrid = document.querySelector("[data-home-investigations]");
   const listGrid = document.querySelector("[data-investigation-list]");
   const rail = document.querySelector("[data-investigation-rail]");
-  if (!homeGrid && !listGrid) return;
+  const archiveSummaryHosts = document.querySelectorAll("[data-archive-summary]");
+  if (!homeGrid && !listGrid && !archiveSummaryHosts.length) return;
   if (homeGrid) homeGrid.innerHTML = renderLoadingState("Looking up featured investigations...");
   if (listGrid) listGrid.innerHTML = renderLoadingState("Looking up investigations...");
   if (rail) rail.innerHTML = renderLoadingState("Looking up filters and map data...");
@@ -374,6 +376,9 @@ async function initInvestigationCards() {
     const posts = await loadPosts();
     const publicState = await getPublicState();
     const canEdit = editorEntryAllowed(publicState);
+    if (archiveSummaryHosts.length) {
+      hydrateArchiveSummaryLinks(posts, publicState);
+    }
     if (homeGrid) {
       const count = Number(homeGrid.getAttribute("data-count") || "2");
       homeGrid.innerHTML = posts
@@ -381,7 +386,6 @@ async function initInvestigationCards() {
         .slice(0, count)
         .map((post) => renderInvestigationCard(post, true))
         .join("");
-      hydrateHomeHeroSnapshot(posts, publicState);
     }
     if (listGrid) {
       const entries = canEdit
@@ -412,27 +416,30 @@ async function initAuthoringEntry() {
   host.innerHTML = `<a class="button" href="./editor.html">Create investigation</a>`;
 }
 
-function hydrateHomeHeroSnapshot(posts, publicState) {
-  const host = document.querySelector("[data-home-summary]");
-  if (!(host instanceof HTMLElement)) return;
+function hydrateArchiveSummaryLinks(posts, publicState) {
+  const hosts = [...document.querySelectorAll("[data-archive-summary]")];
+  if (!hosts.length) return;
   const publishedCount = Array.isArray(posts) ? posts.length : 0;
   const entities = Array.isArray(publicState?.approvedEntities) ? publicState.approvedEntities : [];
   const mappedCount = entities.filter((entity) => Number.isFinite(entity.lat) && Number.isFinite(entity.lng)).length;
   const locationCount = dedupe(entities.map((entity) => String(entity.location || "").trim()).filter(Boolean)).length;
-  host.innerHTML = `
-    <div class="hero-summary__item">
+  const markup = `
+    <a class="hero-summary__item" href="./investigations.html">
       <strong>${publishedCount}</strong>
       <span>Published investigations</span>
-    </div>
-    <div class="hero-summary__item">
+    </a>
+    <a class="hero-summary__item" href="./map.html#entity-index">
       <strong>${entities.length}</strong>
       <span>Tracked entities</span>
-    </div>
-    <div class="hero-summary__item">
+    </a>
+    <a class="hero-summary__item" href="./map.html#map-board">
       <strong>${Math.max(mappedCount, locationCount)}</strong>
-      <span>Locations tied to the archive</span>
-    </div>
+      <span>Locations</span>
+    </a>
   `;
+  for (const host of hosts) {
+    if (host instanceof HTMLElement) host.innerHTML = markup;
+  }
 }
 
 async function initInvestigationDetail() {
@@ -559,6 +566,7 @@ async function initMapPage() {
     .map((entity) => renderEntityCard(entity, entityUsage.get(entity.slug) || []))
     .join("");
   renderLeafletMap(canvas, publicState.approvedEntities);
+  bindMapEntityCards();
   focusRequestedEntity();
 }
 
@@ -932,21 +940,16 @@ function renderInvestigationRail(entries, publicState, filters, canEdit) {
   return `
     <div class="archive-rail">
       <section class="surface-panel archive-filters">
-        <div class="workspace-list__row archive-filters__head">
-          <div>
-            <div class="eyebrow">Filter archive</div>
-            <h3>Refine what is visible</h3>
-          </div>
+        <div class="workspace-list__row archive-filters__head archive-filters__head--bare">
+          <div></div>
           <button class="text-link archive-filters__clear" type="button" data-clear-investigation-filters ${archiveHasActiveFilters(filters) ? "" : "hidden"}>Clear</button>
         </div>
-        <p class="archive-filter-count" data-archive-filter-count></p>
         <div class="archive-filters__form" data-investigation-filters>
           ${
             canEdit
               ? `
                 <label class="archive-filters__field">
-                  <span class="archive-filters__label">Status</span>
-                  <select name="status" aria-label="Filter by status">
+                  <select name="status" aria-label="Filter by status" title="Filter by status">
                     ${renderArchiveStatusOption("", filters.status, "All statuses")}
                     ${renderArchiveStatusOption("draft", filters.status, "Draft")}
                     ${renderArchiveStatusOption("submitted", filters.status, "In review")}
@@ -958,21 +961,16 @@ function renderInvestigationRail(entries, publicState, filters, canEdit) {
               : ""
           }
           <label class="archive-filters__field" data-filter-field="tag">
-            <span class="archive-filters__label">Tag</span>
             <input name="tag" type="text" placeholder="Search tags" value="${escapeAttribute(filters.tag)}" autocomplete="off" data-filter-input="tag">
             <div class="picker-results picker-results--dropdown archive-filters__results" data-filter-results="tag"></div>
           </label>
           <label class="archive-filters__field" data-filter-field="entity">
-            <span class="archive-filters__label">Entity</span>
             <input name="entity" type="text" placeholder="Search entities" value="${escapeAttribute(filters.entity)}" autocomplete="off" data-filter-input="entity">
             <div class="picker-results picker-results--dropdown archive-filters__results" data-filter-results="entity"></div>
           </label>
         </div>
       </section>
       <section class="surface-panel archive-map-card">
-        <div class="eyebrow">Map view</div>
-        <h3>Entity view of the current results</h3>
-        <p class="archive-map-card__summary" data-investigation-map-summary></p>
         <div class="tag-row archive-map-card__tags" data-investigation-map-tags></div>
         <div class="map-board map-board--leaflet map-board--compact" data-investigation-map-canvas></div>
         <div class="button-row">
@@ -1110,13 +1108,7 @@ function renderInvestigationArchiveResults(entries, publicState, canEdit) {
 }
 
 function updateArchiveSummary(filteredEntries, entries) {
-  const count = document.querySelector("[data-archive-filter-count]");
   const clearButton = document.querySelector("[data-clear-investigation-filters]");
-  if (count instanceof HTMLElement) {
-    const total = Array.isArray(entries) ? entries.length : 0;
-    const visible = Array.isArray(filteredEntries) ? filteredEntries.length : 0;
-    count.textContent = `${visible} of ${total} investigation${total === 1 ? "" : "s"} visible`;
-  }
   if (clearButton instanceof HTMLElement) {
     clearButton.hidden = !archiveHasActiveFilters();
   }
@@ -1179,17 +1171,13 @@ function syncArchiveFiltersToUrl(canEdit) {
 }
 
 function updateArchiveMapPreview(filteredEntries, entries, publicState) {
-  const summary = document.querySelector("[data-investigation-map-summary]");
   const tagsHost = document.querySelector("[data-investigation-map-tags]");
   const canvas = document.querySelector("[data-investigation-map-canvas]");
-  if (!(summary instanceof HTMLElement) || !(tagsHost instanceof HTMLElement) || !(canvas instanceof HTMLElement)) return;
+  if (!(tagsHost instanceof HTMLElement) || !(canvas instanceof HTMLElement)) return;
   const activeEntities = archiveEntitiesForEntries(filteredEntries, publicState);
   const defaultEntities = archiveHasActiveFilters() ? [] : archiveEntitiesForEntries(entries, publicState);
   const entities = activeEntities.length ? activeEntities : defaultEntities;
   if (!entities.length) {
-    summary.textContent = archiveHasActiveFilters()
-      ? "No mapped entities appear in the current results yet."
-      : "Entity locations will appear here once approved entries are attached to investigations.";
     tagsHost.innerHTML = "";
     destroyLeafletPreview(canvas);
     canvas.innerHTML = `<div class="map-empty">Map preview unavailable.</div>`;
@@ -1197,7 +1185,6 @@ function updateArchiveMapPreview(filteredEntries, entries, publicState) {
   }
 
   const mappedEntities = entities.filter((entity) => Number.isFinite(entity.lat) && Number.isFinite(entity.lng));
-  summary.textContent = `${entities.length} linked entit${entities.length === 1 ? "y" : "ies"} in the current archive view${mappedEntities.length ? "." : ", but none with map coordinates yet."}`;
   tagsHost.innerHTML = entities
     .slice(0, 4)
     .map((entity) => `<a class="tag tag--link" href="./map.html?entity=${encodeURIComponent(entity.slug)}">${escapeHtml(entity.name)}</a>`)
@@ -1796,7 +1783,7 @@ function shortReviewKey(value) {
 
 function renderEntityCard(entity, posts) {
   return `
-    <article class="entity-card" id="entity-card-${escapeAttribute(entity.slug)}" data-entity-card="${escapeAttribute(entity.slug)}">
+    <article class="entity-card entity-card--interactive" id="entity-card-${escapeAttribute(entity.slug)}" data-entity-card="${escapeAttribute(entity.slug)}" tabindex="0">
       <div class="eyebrow">${escapeHtml(entity.type || "entity")}</div>
       <h3>${escapeHtml(entity.name)}</h3>
       <p>${escapeHtml(entity.location)}</p>
@@ -1838,6 +1825,7 @@ function renderLeafletMap(canvas, entities) {
     }).addTo(state.map);
   }
   if (state.markers) state.markers.remove();
+  state.markerIndex = new Map();
   state.markers = window.L.layerGroup().addTo(state.map);
 
   const points = [];
@@ -1851,6 +1839,7 @@ function renderLeafletMap(canvas, entities) {
       fillColor: "#b3201a",
       fillOpacity: 0.88
     }).addTo(state.markers);
+    state.markerIndex.set(entity.slug, marker);
     marker.bindPopup(`
       <div class="map-popup">
         <strong>${escapeHtml(entity.name)}</strong>
@@ -1873,14 +1862,47 @@ function renderLeafletMap(canvas, entities) {
   window.setTimeout(() => state.map?.invalidateSize(), 50);
 }
 
+function bindMapEntityCards() {
+  for (const card of document.querySelectorAll("[data-entity-card]")) {
+    if (!(card instanceof HTMLElement) || card.dataset.bound === "yes") continue;
+    card.dataset.bound = "yes";
+    card.addEventListener("click", (event) => {
+      const target = event.target;
+      if (target instanceof Element && target.closest(".entity-card__links a")) return;
+      focusEntityOnMap(card.getAttribute("data-entity-card") || "");
+    });
+    card.addEventListener("keydown", (event) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      const target = event.target;
+      if (target instanceof Element && target.closest(".entity-card__links a")) return;
+      event.preventDefault();
+      focusEntityOnMap(card.getAttribute("data-entity-card") || "");
+    });
+  }
+}
+
+function focusEntityOnMap(slug) {
+  const clean = cleanSlug(slug || "");
+  if (!clean) return;
+  const marker = state.markerIndex?.get(clean);
+  const card = document.querySelector(`[data-entity-card="${clean}"]`);
+  if (card instanceof HTMLElement) {
+    for (const item of document.querySelectorAll(".entity-card--focus")) item.classList.remove("entity-card--focus");
+    card.classList.add("entity-card--focus");
+  }
+  if (marker && state.map) {
+    const latLng = marker.getLatLng();
+    state.map.flyTo(latLng, Math.max(state.map.getZoom(), 8), { duration: 0.45 });
+    marker.openPopup();
+  }
+}
+
 function focusRequestedEntity() {
   const requested = cleanSlug(new URLSearchParams(window.location.search).get("entity") || "");
   if (!requested) return;
+  focusEntityOnMap(requested);
   const card = document.querySelector(`[data-entity-card="${requested}"]`);
-  if (card) {
-    card.classList.add("entity-card--focus");
-    card.scrollIntoView({ behavior: "smooth", block: "center" });
-  }
+  if (card instanceof HTMLElement) card.scrollIntoView({ behavior: "smooth", block: "center" });
 }
 
 async function getPublicState() {

--- a/styles.css
+++ b/styles.css
@@ -547,6 +547,10 @@ h3 {
   gap: 0.8rem;
 }
 
+.hero-summary--stack {
+  grid-template-columns: 1fr;
+}
+
 .hero-summary__item {
   display: grid;
   gap: 0.2rem;
@@ -554,16 +558,41 @@ h3 {
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.08);
+  text-decoration: none;
+  transition: transform 140ms ease, border-color 140ms ease, background-color 140ms ease;
+}
+
+.hero-summary__item:hover,
+.hero-summary__item:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.09);
 }
 
 .hero-summary__item strong {
   font-size: clamp(1.45rem, 3vw, 2rem);
   font-family: "Spectral", serif;
+  color: inherit;
 }
 
 .hero-summary__item span {
   color: rgba(248, 243, 238, 0.78);
   font-size: 0.88rem;
+}
+
+.hero-summary--light .hero-summary__item {
+  background: rgba(18, 18, 18, 0.04);
+  border-color: rgba(18, 18, 18, 0.08);
+}
+
+.hero-summary--light .hero-summary__item:hover,
+.hero-summary--light .hero-summary__item:focus-visible {
+  background: rgba(156, 29, 24, 0.05);
+  border-color: rgba(156, 29, 24, 0.18);
+}
+
+.hero-summary--light .hero-summary__item span {
+  color: var(--ink-soft);
 }
 
 .hero__actions,
@@ -731,6 +760,10 @@ h3 {
   align-items: stretch;
 }
 
+.card-grid--duo {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .card-grid--equal > * {
   height: 100%;
 }
@@ -777,6 +810,10 @@ h3 {
   align-items: start;
 }
 
+.archive-filters__head--bare {
+  min-height: 1rem;
+}
+
 .archive-filters__form {
   display: grid;
   grid-template-columns: 1fr;
@@ -789,25 +826,11 @@ h3 {
   min-width: 0;
 }
 
-.archive-filters__label {
-  font-size: 0.74rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  font-family: "IBM Plex Mono", monospace;
-  color: var(--ink-soft);
-}
-
 .archive-filters__clear {
   padding: 0;
   border: 0;
   background: transparent;
   cursor: pointer;
-}
-
-.archive-filter-count {
-  margin: 0;
-  color: var(--ink-soft);
-  font-size: 0.92rem;
 }
 
 .workspace-search {
@@ -839,11 +862,6 @@ h3 {
 .archive-map-card {
   display: grid;
   gap: 0.9rem;
-}
-
-.archive-map-card__summary {
-  margin: 0;
-  color: var(--ink-soft);
 }
 
 .archive-map-card__tags {
@@ -1465,16 +1483,18 @@ h3 {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.55rem;
+  gap: 1rem;
+  min-height: 3.35rem;
   border-bottom: 1px solid rgba(18, 18, 18, 0.08);
   background: #fff;
-  padding: 0.95rem 1rem;
+  padding: 0 1.1rem;
 }
 
 .editor-markdown-field .toastui-editor-toolbar-group {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
+  align-items: center;
+  gap: 1rem;
   margin: 0 !important;
   padding-right: 0 !important;
   border-right: 0 !important;
@@ -1496,9 +1516,9 @@ h3 {
 
 .editor-markdown-field .toastui-editor-toolbar-icons,
 .editor-markdown-field .toastui-editor-toolbar-icons.last {
-  border-radius: 999px;
-  border: 1px solid rgba(18, 18, 18, 0.08);
-  background-color: rgba(255, 255, 255, 0.98);
+  border-radius: 0;
+  border: 0;
+  background-color: transparent;
   background-image: none !important;
   color: var(--ink);
   display: inline-flex;
@@ -1506,14 +1526,14 @@ h3 {
   justify-content: center;
   width: auto !important;
   min-width: 0;
-  height: 2.6rem !important;
-  padding: 0 1rem;
+  height: auto !important;
+  padding: 0.95rem 0;
   text-indent: 0 !important;
   white-space: nowrap;
   overflow: visible;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  box-shadow: none;
   font-family: "IBM Plex Sans", sans-serif;
-  font-size: 0.82rem !important;
+  font-size: 0.98rem !important;
   font-weight: 600;
   letter-spacing: 0.01em;
   line-height: 1;
@@ -1531,8 +1551,11 @@ h3 {
 .editor-markdown-field .toastui-editor-toolbar-icons.active,
 .editor-markdown-field .toastui-editor-toolbar-icons.last:hover,
 .editor-markdown-field .toastui-editor-toolbar-icons.last.active {
-  background-color: rgba(156, 29, 24, 0.1);
-  border-color: rgba(156, 29, 24, 0.22);
+  background-color: transparent;
+  border-color: transparent;
+  color: var(--accent-deep);
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
 }
 
 .editor-markdown-field .toastui-editor-toolbar-divider {
@@ -1909,6 +1932,10 @@ h3 {
   border-radius: 18px;
   background: rgba(18, 18, 18, 0.05);
   border: 1px solid rgba(18, 18, 18, 0.08);
+}
+
+.entity-card--interactive {
+  cursor: pointer;
 }
 
 .entity-card--focus {


### PR DESCRIPTION
## Summary\n- simplify the home and about archive rails into linked archive stats\n- compact the investigations right rail and keep the map preview useful without redundant labels\n- make entity cards on the map page focus and zoom the matching map marker\n- rebalance the merch layout into an even two-column composition\n- flatten the editor toolbar into inline text controls on a clean white bar and add the entity-wiki follow-up to the roadmap\n\n## Testing\n- node --check scripts/app.js\n- Firefox headless screenshots for home, about, merch, investigations, and editor\n- Firefox headless check that investigation filter input keeps focus and shows suggestions\n- Firefox headless check that clicking an entity card opens the matching map popup