### PR TITLE
Polish archive rail and investigation detail UX

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,8 @@ The current build is meant to be a practical, low-overhead publishing and coordi
 
 - Add transparent page editing for static pages such as Home and About. The intended workflow is a keyboard shortcut (`Ctrl+Shift+E`) that reveals a fixed bottom control bar with revert, undo, redo, and save actions while the page itself is edited in place. This editing mode is meant for queued snapshot-to-GitHub bakedown, not synchronized live co-editing.
 - Add image handling inside the document editor, including attachment, placement controls (left, right, full width), and markdown-safe storage through the existing blob workflow.
-- Add a navigable entity wiki that can enrich facilities, companies, agencies, and related records with expandable fields, history, and clearer cross-links into investigations and the map.
+- Add a navigable entity wiki that can enrich facilities, companies, agencies, and related records with expandable fields, history, clearer cross-links into investigations and the map, and a richer type / class / taxonomy model.
+- Add collaborative editing for drafts so more than one approved user can work on a document without relying only on queued revisions and review handoffs.
 - Add stronger map and archive views as the entity and location dataset grows.
 - Improve collaboration tools for volunteers, including clearer review states and richer discussion around submissions.
 - Package the reusable parts of the system so future campaign sites can launch with less custom setup.

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
             <div class="hero__panel-top">
               <div>
                 <div class="eyebrow">Archive</div>
-                <h3>Explore a living archive.</h3>
+                <h3>Explore the archive.</h3>
               </div>
             </div>
             <div class="hero__panel-body">

--- a/investigation.html
+++ b/investigation.html
@@ -38,13 +38,26 @@
       </section>
 
       <section class="section">
-        <div class="wrap article-stack">
-          <p class="article-inline-meta" data-investigation-meta></p>
-          <article class="article-shell surface-panel article-shell--light" data-investigation-article></article>
-          <section class="surface-panel article-notes-panel" data-investigation-records-shell hidden>
-            <div class="eyebrow">Structured notes</div>
-            <div class="record-list" data-investigation-records></div>
-          </section>
+        <div class="wrap page-layout page-layout--article">
+          <div class="article-stack">
+            <p class="article-inline-meta" data-investigation-meta></p>
+            <article class="article-shell surface-panel article-shell--light" data-investigation-article></article>
+            <section class="surface-panel article-review-panel" data-investigation-review-shell hidden></section>
+          </div>
+          <aside class="article-aside">
+            <section class="surface-panel article-aside-panel" data-investigation-tags-shell hidden>
+              <div class="eyebrow">Tags</div>
+              <div class="tag-row tag-row--compact" data-investigation-tags></div>
+            </section>
+            <section class="surface-panel article-aside-panel" data-investigation-records-shell hidden>
+              <div class="eyebrow">Structured notes</div>
+              <div class="record-list" data-investigation-records></div>
+            </section>
+            <section class="surface-panel article-aside-panel" data-investigation-map-shell hidden>
+              <div class="eyebrow">Entity view</div>
+              <div class="map-board map-board--leaflet map-board--compact" data-investigation-map-canvas></div>
+            </section>
+          </aside>
         </div>
       </section>
 

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -423,6 +423,9 @@ function hydrateArchiveSummaryLinks(posts, publicState) {
   const entities = Array.isArray(publicState?.approvedEntities) ? publicState.approvedEntities : [];
   const mappedCount = entities.filter((entity) => Number.isFinite(entity.lat) && Number.isFinite(entity.lng)).length;
   const locationCount = dedupe(entities.map((entity) => String(entity.location || "").trim()).filter(Boolean)).length;
+  const tagCount = dedupe(
+    (Array.isArray(posts) ? posts : []).flatMap((post) => (Array.isArray(post?.tags) ? post.tags : []))
+  ).length;
   const markup = `
     <a class="hero-summary__item" href="./investigations.html">
       <strong>${publishedCount}</strong>
@@ -436,6 +439,10 @@ function hydrateArchiveSummaryLinks(posts, publicState) {
       <strong>${Math.max(mappedCount, locationCount)}</strong>
       <span>Locations</span>
     </a>
+    <a class="hero-summary__item" href="./investigations.html">
+      <strong>${tagCount}</strong>
+      <span>Archive tags</span>
+    </a>
   `;
   for (const host of hosts) {
     if (host instanceof HTMLElement) host.innerHTML = markup;
@@ -447,7 +454,12 @@ async function initInvestigationDetail() {
   if (!article) return;
   article.innerHTML = renderLoadingState("Looking up article...");
   const commentPanel = document.querySelector("[data-comment-panel]");
+  const reviewShell = document.querySelector("[data-investigation-review-shell]");
+  const tagsShell = document.querySelector("[data-investigation-tags-shell]");
+  const tagsHost = document.querySelector("[data-investigation-tags]");
   const recordsShell = document.querySelector("[data-investigation-records-shell]");
+  const mapShell = document.querySelector("[data-investigation-map-shell]");
+  const mapCanvas = document.querySelector("[data-investigation-map-canvas]");
   if (commentPanel) commentPanel.innerHTML = renderLoadingState("Looking up discussion...");
 
   try {
@@ -475,6 +487,11 @@ async function initInvestigationDetail() {
     setText("[data-investigation-meta]", buildArticleMetaLine(post));
     const tags = document.querySelector("[data-investigation-kicker]");
     if (tags) tags.innerHTML = renderTagList(post.tags);
+    if (tagsHost instanceof HTMLElement && tagsShell instanceof HTMLElement) {
+      const hasTags = Array.isArray(post.tags) && post.tags.length;
+      tagsHost.innerHTML = hasTags ? renderTagList(post.tags) : "";
+      tagsShell.hidden = !hasTags;
+    }
     const records = document.querySelector("[data-investigation-records]");
     if (records) {
       const hasRecords = Array.isArray(post.records) && post.records.length;
@@ -493,20 +510,26 @@ async function initInvestigationDetail() {
     }
 
     enrichArticleEntities(article, publicState);
-    let reviewShell = document.querySelector("[data-investigation-review-shell]");
-    if (isDraftPreview && !(reviewShell instanceof HTMLElement)) {
-      reviewShell = document.createElement("section");
-      reviewShell.className = "surface-panel article-review-panel";
-      reviewShell.setAttribute("data-investigation-review-shell", "");
-      article.insertAdjacentElement("afterend", reviewShell);
-    }
     if (reviewShell instanceof HTMLElement) {
       if (isDraftPreview) {
         reviewShell.hidden = false;
         reviewShell.innerHTML = renderReviewPreviewPanel(draft);
         bindReviewPreviewPanel(reviewShell, draft);
       } else {
-        reviewShell.remove();
+        reviewShell.hidden = true;
+        reviewShell.innerHTML = "";
+      }
+    }
+    if (mapShell instanceof HTMLElement && mapCanvas instanceof HTMLElement) {
+      const detailEntities = archiveEntitiesForEntries([post], publicState);
+      const mappedEntities = detailEntities.filter((entity) => Number.isFinite(entity.lat) && Number.isFinite(entity.lng));
+      if (mappedEntities.length) {
+        mapShell.hidden = false;
+        renderLeafletPreviewMap(mapCanvas, mappedEntities);
+      } else {
+        mapShell.hidden = true;
+        destroyLeafletPreview(mapCanvas);
+        mapCanvas.innerHTML = "";
       }
     }
     if (commentPanel instanceof HTMLElement) {
@@ -520,11 +543,17 @@ async function initInvestigationDetail() {
     document.title = `${post.title} | ${SITE.shortName}`;
   } catch {
     renderError(article, "This case file could not be loaded.");
-    const reviewShell = document.querySelector("[data-investigation-review-shell]");
     if (reviewShell instanceof HTMLElement) {
-      reviewShell.remove();
+      reviewShell.hidden = true;
+      reviewShell.innerHTML = "";
     }
+    if (tagsShell instanceof HTMLElement) tagsShell.hidden = true;
     if (recordsShell instanceof HTMLElement) recordsShell.hidden = true;
+    if (mapShell instanceof HTMLElement) mapShell.hidden = true;
+    if (mapCanvas instanceof HTMLElement) {
+      destroyLeafletPreview(mapCanvas);
+      mapCanvas.innerHTML = "";
+    }
   }
 }
 

--- a/scripts/editor.js
+++ b/scripts/editor.js
@@ -105,9 +105,9 @@ function renderEditorShell() {
             <p>${editorState.currentSlug ? "Keep shaping the draft, then send the next version into review when it is ready." : "Write the title, summary, and full body here. Drafts save as you work and can be sent into review when they are ready."}</p>
           </div>
           <div class="editor-actions__controls">
-            <div class="editor-save-state" data-editor-status aria-live="polite">Draft saves automatically as you work.</div>
+            <div class="editor-save-state" data-editor-status aria-live="polite">Autosave is on. Save draft now pushes the latest version immediately.</div>
             <div class="button-row">
-              <button class="button-ghost" type="button" data-editor-save>Save now</button>
+              <button class="button-ghost" type="button" data-editor-save>Save draft now</button>
               <button class="button" type="button" data-editor-submit>Send to review</button>
             </div>
           </div>
@@ -457,7 +457,7 @@ function updateMetaPanel(message = "") {
     delete host.dataset.state;
     return;
   }
-  host.textContent = "Draft saves automatically as you work.";
+  host.textContent = "Autosave is on. Save draft now pushes the latest version immediately.";
   delete host.dataset.state;
 }
 
@@ -841,11 +841,13 @@ function decorateToolbar(surface) {
     const label = labels.get(String(button.getAttribute("aria-label") || "").trim());
     if (!label) return;
     button.classList.add("editor-toolbar-button");
+    button.setAttribute("aria-label", label);
+    button.removeAttribute("title");
     const icon = button.querySelector(".toastui-editor-toolbar-icons, .toastui-editor-toolbar-icons.last");
     if (icon instanceof HTMLElement) {
       icon.textContent = label;
       icon.setAttribute("aria-hidden", "true");
-      icon.setAttribute("title", "");
+      icon.removeAttribute("title");
       icon.classList.add("editor-toolbar-chip");
     } else {
       button.textContent = label;

--- a/styles.css
+++ b/styles.css
@@ -580,6 +580,10 @@ h3 {
   font-size: 0.88rem;
 }
 
+.hero-summary--stack .hero-summary__item {
+  min-height: 5.4rem;
+}
+
 .hero-summary--light .hero-summary__item {
   background: rgba(18, 18, 18, 0.04);
   border-color: rgba(18, 18, 18, 0.08);
@@ -1243,6 +1247,20 @@ h3 {
   gap: 1rem;
 }
 
+.page-layout--article {
+  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.72fr);
+  align-items: start;
+}
+
+.article-aside-panel {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.tag-row--compact {
+  margin: 0;
+}
+
 .meta-list,
 .relay-list,
 .record-list,
@@ -1482,7 +1500,7 @@ h3 {
 .editor-markdown-field .toastui-editor-defaultUI-toolbar {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: stretch;
   gap: 1rem;
   min-height: 3.35rem;
   border-bottom: 1px solid rgba(18, 18, 18, 0.08);
@@ -1493,11 +1511,12 @@ h3 {
 .editor-markdown-field .toastui-editor-toolbar-group {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: stretch;
   gap: 1rem;
   margin: 0 !important;
   padding-right: 0 !important;
   border-right: 0 !important;
+  min-height: 100%;
 }
 
 .editor-markdown-field .toastui-editor-defaultUI-toolbar button {
@@ -1506,11 +1525,18 @@ h3 {
   justify-content: center;
   width: auto;
   min-width: 0;
-  height: auto;
+  height: 100%;
   margin: 0;
   padding: 0;
   border: 0;
   background: transparent;
+  box-shadow: none;
+}
+
+.editor-markdown-field .toastui-editor-defaultUI-toolbar button:hover,
+.editor-markdown-field .toastui-editor-defaultUI-toolbar button:focus-visible {
+  background: transparent;
+  border-color: transparent;
   box-shadow: none;
 }
 
@@ -1526,8 +1552,8 @@ h3 {
   justify-content: center;
   width: auto !important;
   min-width: 0;
-  height: auto !important;
-  padding: 0.95rem 0;
+  height: 100% !important;
+  padding: 0;
   text-indent: 0 !important;
   white-space: nowrap;
   overflow: visible;
@@ -1548,18 +1574,24 @@ h3 {
 }
 
 .editor-markdown-field .toastui-editor-toolbar-icons:hover,
-.editor-markdown-field .toastui-editor-toolbar-icons.active,
-.editor-markdown-field .toastui-editor-toolbar-icons.last:hover,
-.editor-markdown-field .toastui-editor-toolbar-icons.last.active {
+.editor-markdown-field .toastui-editor-toolbar-icons.last:hover {
   background-color: transparent;
   border-color: transparent;
+  color: rgba(18, 18, 18, 0.72);
+  text-decoration: none;
+}
+
+.editor-markdown-field .toastui-editor-toolbar-icons.active,
+.editor-markdown-field .toastui-editor-toolbar-icons.last.active {
   color: var(--accent-deep);
-  text-decoration: underline;
-  text-underline-offset: 0.18em;
 }
 
 .editor-markdown-field .toastui-editor-toolbar-divider {
   display: none;
+}
+
+.editor-markdown-field .toastui-editor-tooltip {
+  display: none !important;
 }
 
 .editor-markdown-field .toastui-editor-main {


### PR DESCRIPTION
## Summary\n- add a fourth archive stat and tighten the home rail copy\n- move investigation detail metadata into a right rail with tags, structured notes, and a minimap\n- clean the Toast editor controls, remove tooltip noise, and clarify the immediate draft-save action\n- track collaborative editing and richer entity taxonomy work in the roadmap\n\n## Validation\n- 
ode --check scripts/app.js\n- 
ode --check scripts/editor.js\n- Firefox headless screenshots for home, editor, and investigation detail\n\nCloses #16