### PR TITLE
Tune archive rail width and empty preview copy

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1409,7 +1409,7 @@ function updateArchiveMapPreview(filteredEntries, entries, publicState) {
   if (!entities.length) {
     tagsHost.innerHTML = "";
     destroyLeafletPreview(canvas);
-    canvas.innerHTML = `<div class="map-empty">Map preview unavailable.</div>`;
+    canvas.innerHTML = `<div class="map-empty">${archiveHasActiveFilters() ? "No locations tagged in filtered results." : "No locations tagged in the archive yet."}</div>`;
     return;
   }
 

--- a/styles.css
+++ b/styles.css
@@ -785,7 +785,7 @@ h3 {
 
 .archive-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(248px, 300px);
+  grid-template-columns: minmax(0, 2fr) minmax(290px, 1fr);
   gap: 1.2rem;
   align-items: start;
 }


### PR DESCRIPTION
## What changed
- widened the investigations rail to sit at roughly one third of the archive layout
- changed the empty rail map copy to plain language when filtered results have no tagged locations

## Verification
- node --check scripts/app.js
- Firefox headless check confirmed the rail width lands at about 32.8% of the archive layout
- Firefox headless check confirmed the empty preview copy reads: "No locations tagged in filtered results."

Closes #26
