### PR TITLE
Polish archive map label and workspace loading

### DIFF
--- a/scripts/admin.js
+++ b/scripts/admin.js
@@ -240,7 +240,9 @@ async function refreshWorkspace(force = false) {
 
 function renderWorkspaceLoading(message) {
   const shell = document.querySelector("[data-workspace-shell]");
+  const title = document.querySelector("[data-workspace-title]");
   const lede = document.querySelector("[data-workspace-lede]");
+  if (title) title.textContent = "Workspace";
   if (lede) lede.textContent = message;
   if (shell) shell.innerHTML = renderLoadingState(message);
 }

--- a/styles.css
+++ b/styles.css
@@ -2031,7 +2031,7 @@ h3 {
 }
 
 .map-board::before {
-  content: "Live entity layer";
+  content: "Map";
   position: absolute;
   left: 1rem;
   top: 1rem;
@@ -2183,6 +2183,9 @@ h3 {
 
 .picker-results--dropdown {
   padding: 0.5rem;
+  max-height: 15rem;
+  overflow: auto;
+  overscroll-behavior: contain;
   border-radius: 18px;
   border: 1px solid rgba(18, 18, 18, 0.08);
   background: rgba(250, 247, 241, 0.96);


### PR DESCRIPTION
## What changed
- changed the compact archive map label from "Live entity layer" to "Map"
- capped picker and archive dropdown height so longer suggestion lists scroll instead of stretching the panel
- stopped the workspace from flashing a "Log in" heading while an existing signed-in session is still loading

## Verification
- Firefox headless check confirmed the compact archive map now reads `Map`
- Firefox headless check confirmed the signed-in admin page shows `Workspace` during the loading state

Closes #30
