### PR TITLE
Add in-place static page editing

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,7 @@ The current build is meant to be a practical, low-overhead publishing and coordi
 - Keep improving relay compatibility and degraded-mode behavior so the site remains usable even when some relays are noisy or incomplete.
 - Tighten the Linux pinner setup path into a repeatable install, update, and recovery workflow for non-developer operators.
 - Expand end-to-end browser validation around submissions, moderation, publishing, and comment handling before each release.
+- Wire the new in-place static page editing workflow into bakedown / review so Home and About snapshots can move cleanly from browser edits into the repository layer.
 
 ## Publishing Workflow
 
@@ -17,7 +18,7 @@ The current build is meant to be a practical, low-overhead publishing and coordi
 
 ## Longer Term
 
-- Add transparent page editing for static pages such as Home and About. The intended workflow is a keyboard shortcut (`Ctrl+Shift+E`) that reveals a fixed bottom control bar with revert, undo, redo, and save actions while the page itself is edited in place. This editing mode is meant for queued snapshot-to-GitHub bakedown, not synchronized live co-editing.
+- Expand transparent page editing beyond Home and About, and add stronger review/history handling around queued page snapshots.
 - Add image handling inside the document editor, including attachment, placement controls (left, right, full width), and markdown-safe storage through the existing blob workflow.
 - Add a navigable entity wiki that can enrich facilities, companies, agencies, and related records with expandable fields, history, clearer cross-links into investigations and the map, and a richer type / class / taxonomy model.
 - Add collaborative editing for drafts so more than one approved user can work on a document without relying only on queued revisions and review handoffs.

--- a/about.html
+++ b/about.html
@@ -30,28 +30,28 @@
     <main>
       <section class="hero">
         <div class="wrap">
-          <div class="eyebrow">About us</div>
-          <h1>A focused public-records project, not a content mill.</h1>
-          <p class="hero__lede">The True Cost Project is positioned as a clean investigative hub: publish documented findings, show the underlying records, and give others a way to replicate or extend the work.</p>
+          <div class="eyebrow" data-static-edit="about.hero.eyebrow">About us</div>
+          <h1 data-static-edit="about.hero.title">A focused public-records project, not a content mill.</h1>
+          <p class="hero__lede" data-static-edit="about.hero.lede">The True Cost Project is positioned as a clean investigative hub: publish documented findings, show the underlying records, and give others a way to replicate or extend the work.</p>
         </div>
       </section>
 
       <section class="section">
         <div class="wrap card-grid">
           <article class="info-card">
-            <div class="eyebrow">Purpose</div>
-            <h3>Expose public support systems</h3>
-            <p>Track grants, tax breaks, contracts, enforcement costs, and other public resources that prop up industrial animal agriculture.</p>
+            <div class="eyebrow" data-static-edit="about.cards.purpose.eyebrow">Purpose</div>
+            <h3 data-static-edit="about.cards.purpose.title">Expose public support systems</h3>
+            <p data-static-edit="about.cards.purpose.body">Track grants, tax breaks, contracts, enforcement costs, and other public resources that prop up industrial animal agriculture.</p>
           </article>
           <article class="info-card">
-            <div class="eyebrow">Approach</div>
-            <h3>Lead with records</h3>
-            <p>Use budgets, minutes, invoices, correspondence, and footage requests to build accountability reporting that can stand up to scrutiny.</p>
+            <div class="eyebrow" data-static-edit="about.cards.approach.eyebrow">Approach</div>
+            <h3 data-static-edit="about.cards.approach.title">Lead with records</h3>
+            <p data-static-edit="about.cards.approach.body">Use budgets, minutes, invoices, correspondence, and footage requests to build accountability reporting that can stand up to scrutiny.</p>
           </article>
           <article class="info-card">
-            <div class="eyebrow">Audience</div>
-            <h3>Readers and researchers</h3>
-            <p>Publish in a format that works for journalists, donors, organizers, and local people who want to investigate similar patterns in their own areas.</p>
+            <div class="eyebrow" data-static-edit="about.cards.audience.eyebrow">Audience</div>
+            <h3 data-static-edit="about.cards.audience.title">Readers and researchers</h3>
+            <p data-static-edit="about.cards.audience.body">Publish in a format that works for journalists, donors, organizers, and local people who want to investigate similar patterns in their own areas.</p>
           </article>
         </div>
       </section>
@@ -59,15 +59,15 @@
       <section class="section">
         <div class="wrap support-grid support-grid--duo">
           <div class="surface-panel surface-panel--stacked">
-            <div class="eyebrow">Editorial posture</div>
-            <h2>Credible, plain, and evidence-first.</h2>
-            <p>The project aims to keep the tone plain and evidence-first: enough context to orient readers, enough documentation to support scrutiny, and enough clarity for others to build on the work.</p>
-            <p>This page can also hold future background on collaborators, media contact details, or a longer statement of purpose if that becomes useful.</p>
+            <div class="eyebrow" data-static-edit="about.editorial.eyebrow">Editorial posture</div>
+            <h2 data-static-edit="about.editorial.title">Credible, plain, and evidence-first.</h2>
+            <p data-static-edit="about.editorial.bodyPrimary">The project aims to keep the tone plain and evidence-first: enough context to orient readers, enough documentation to support scrutiny, and enough clarity for others to build on the work.</p>
+            <p data-static-edit="about.editorial.bodySecondary">This page can also hold future background on collaborators, media contact details, or a longer statement of purpose if that becomes useful.</p>
           </div>
           <section class="surface-panel surface-panel--stacked">
-            <div class="eyebrow">Dive in</div>
-            <h2>See what the project is building.</h2>
-            <p>Move from this overview into the archive, the entity index, or the geographic view of the work.</p>
+            <div class="eyebrow" data-static-edit="about.divein.eyebrow">Dive in</div>
+            <h2 data-static-edit="about.divein.title">See what the project is building.</h2>
+            <p data-static-edit="about.divein.body">Move from this overview into the archive, the entity index, or the geographic view of the work.</p>
             <div class="hero-summary hero-summary--light hero-summary--stack" data-archive-summary></div>
           </section>
         </div>

--- a/index.html
+++ b/index.html
@@ -32,20 +32,20 @@
       <section class="hero hero--home">
         <div class="wrap hero__grid">
           <div class="hero__copy">
-            <div class="eyebrow">Public records. Public money. Public accountability.</div>
-            <h1>Follow the money behind animal agriculture.</h1>
-            <p class="hero__lede">The True Cost Project documents how taxpayer resources move into industrial animal agriculture, then turns those records into clear, public-facing investigations and practical tools others can use.</p>
+            <div class="eyebrow" data-static-edit="home.hero.eyebrow">Public records. Public money. Public accountability.</div>
+            <h1 data-static-edit="home.hero.title">Follow the money behind animal agriculture.</h1>
+            <p class="hero__lede" data-static-edit="home.hero.lede">The True Cost Project documents how taxpayer resources move into industrial animal agriculture, then turns those records into clear, public-facing investigations and practical tools others can use.</p>
             <div class="hero__actions">
-              <a class="button" href="./investigations.html">Read investigations</a>
-              <a class="button-ghost" href="./guide.html">Learn the method</a>
-              <a class="button-dark" href="./submit.html">Submit a tip</a>
+              <a class="button" href="./investigations.html" data-static-edit="home.hero.ctaPrimary">Read investigations</a>
+              <a class="button-ghost" href="./guide.html" data-static-edit="home.hero.ctaGuide">Learn the method</a>
+              <a class="button-dark" href="./submit.html" data-static-edit="home.hero.ctaSubmit">Submit a tip</a>
             </div>
           </div>
           <aside class="hero__panel">
             <div class="hero__panel-top">
               <div>
-                <div class="eyebrow">Archive</div>
-                <h3>Explore the archive.</h3>
+                <div class="eyebrow" data-static-edit="home.archive.eyebrow">Archive</div>
+                <h3 data-static-edit="home.archive.title">Explore the archive.</h3>
               </div>
             </div>
             <div class="hero__panel-body">
@@ -58,8 +58,8 @@
       <section class="section">
         <div class="wrap section__head">
           <div>
-            <div class="eyebrow">Investigations</div>
-            <h2>Featured case files</h2>
+            <div class="eyebrow" data-static-edit="home.featured.eyebrow">Investigations</div>
+            <h2 data-static-edit="home.featured.title">Featured case files</h2>
           </div>
         </div>
         <div class="wrap card-grid" data-home-investigations data-count="2"></div>
@@ -68,25 +68,25 @@
       <section class="section">
         <div class="wrap section__head">
           <div>
-            <div class="eyebrow">Method</div>
-            <h2>How the work happens</h2>
+            <div class="eyebrow" data-static-edit="home.method.eyebrow">Method</div>
+            <h2 data-static-edit="home.method.title">How the work happens</h2>
           </div>
         </div>
         <div class="wrap card-grid">
           <article class="info-card">
-            <div class="eyebrow">1. Request</div>
-            <h3>Pull the records first</h3>
-            <p>Requests, agency logs, and document organization form the base layer before any public write-up begins.</p>
+            <div class="eyebrow" data-static-edit="home.method.request.eyebrow">1. Request</div>
+            <h3 data-static-edit="home.method.request.title">Pull the records first</h3>
+            <p data-static-edit="home.method.request.body">Requests, agency logs, and document organization form the base layer before any public write-up begins.</p>
           </article>
           <article class="info-card">
-            <div class="eyebrow">2. Trace</div>
-            <h3>Map the funding trail</h3>
-            <p>Findings can connect agencies, facilities, companies, and local sites so readers can track a story spatially as well as chronologically.</p>
+            <div class="eyebrow" data-static-edit="home.method.trace.eyebrow">2. Trace</div>
+            <h3 data-static-edit="home.method.trace.title">Map the funding trail</h3>
+            <p data-static-edit="home.method.trace.body">Findings can connect agencies, facilities, companies, and local sites so readers can track a story spatially as well as chronologically.</p>
           </article>
           <article class="info-card">
-            <div class="eyebrow">3. Publish</div>
-            <h3>Share the evidence cleanly</h3>
-            <p>Published investigations should be readable to the public and useful to anyone following up with more records work.</p>
+            <div class="eyebrow" data-static-edit="home.method.publish.eyebrow">3. Publish</div>
+            <h3 data-static-edit="home.method.publish.title">Share the evidence cleanly</h3>
+            <p data-static-edit="home.method.publish.body">Published investigations should be readable to the public and useful to anyone following up with more records work.</p>
           </article>
         </div>
       </section>
@@ -94,13 +94,13 @@
       <section class="section">
         <div class="wrap">
           <div class="surface-panel">
-            <div class="eyebrow">Get involved</div>
-            <h2>Help expand the work.</h2>
-            <p>Support can mean sharing leads, passing along documents, helping with research, or sustaining the records work financially.</p>
+            <div class="eyebrow" data-static-edit="home.getinvolved.eyebrow">Get involved</div>
+            <h2 data-static-edit="home.getinvolved.title">Help expand the work.</h2>
+            <p data-static-edit="home.getinvolved.body">Support can mean sharing leads, passing along documents, helping with research, or sustaining the records work financially.</p>
             <div class="button-row">
-              <a class="button" href="./get-involved.html">Get involved</a>
-              <a class="button-ghost" href="./submit.html">Submit material</a>
-              <a class="button-ghost" href="./map.html">Browse the map</a>
+              <a class="button" href="./get-involved.html" data-static-edit="home.getinvolved.ctaPrimary">Get involved</a>
+              <a class="button-ghost" href="./submit.html" data-static-edit="home.getinvolved.ctaSubmit">Submit material</a>
+              <a class="button-ghost" href="./map.html" data-static-edit="home.getinvolved.ctaMap">Browse the map</a>
             </div>
           </div>
         </div>
@@ -108,12 +108,12 @@
 
       <section class="section">
         <div class="wrap surface-panel quote-card">
-          <div class="eyebrow">Support</div>
-          <h2>Help keep the records work public.</h2>
-          <p>Donations support records requests, document review, organizing notes, and the time it takes to turn raw records into public investigations.</p>
+          <div class="eyebrow" data-static-edit="home.support.eyebrow">Support</div>
+          <h2 data-static-edit="home.support.title">Help keep the records work public.</h2>
+          <p data-static-edit="home.support.body">Donations support records requests, document review, organizing notes, and the time it takes to turn raw records into public investigations.</p>
           <div class="button-row">
-            <a class="button" href="./get-involved.html">Donate or collaborate</a>
-            <a class="button-ghost" href="./submit.html">Send a lead</a>
+            <a class="button" href="./get-involved.html" data-static-edit="home.support.ctaDonate">Donate or collaborate</a>
+            <a class="button-ghost" href="./submit.html" data-static-edit="home.support.ctaLead">Send a lead</a>
           </div>
         </div>
       </section>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -45,6 +45,8 @@ const ARCHIVE_STATUS_OPTIONS = [
   { value: "posted", label: "Posted" }
 ];
 
+const STATIC_EDITABLE_PAGES = new Set(["home", "about"]);
+
 const state = {
   session: getStoredSession(),
   guestSession: getStoredGuestSession(),
@@ -60,6 +62,7 @@ const state = {
   archiveFilterOpenField: "",
   archiveStatusMenuOpen: false,
   archiveFilterTimer: null,
+  staticEdit: null,
   map: null,
   markers: null,
   markerIndex: null
@@ -73,6 +76,7 @@ document.addEventListener("DOMContentLoaded", () => {
   void initMarkdownArticles();
   void initMapPage();
   void initAuthoringEntry();
+  void initStaticPageEditing();
   window.addEventListener("truecost:session-changed", handleSessionChanged);
 });
 
@@ -220,6 +224,9 @@ function handleSessionChanged() {
   renderNavigation();
   if (state.session) {
     void hydrateNotifications(true);
+    if (!state.staticEdit) {
+      void initStaticPageEditing();
+    }
   }
 }
 
@@ -276,7 +283,7 @@ function renderNavigation() {
     <a class="${navLinkClass(page, "about")}" href="./about.html">About</a>
     <a class="${navLinkClass(page, "merch")}" href="./merch.html">Merch</a>
     <div class="profile-menu ${NAV_KEYS.workspace.includes(page) ? "is-current" : ""} ${state.profileMenuOpen ? "is-open" : ""}" data-profile-menu>
-      <button class="profile-menu__toggle ${currentUser?.avatarUrl ? "has-avatar" : !isLoggedIn ? "is-wordmark" : ""}" type="button" data-profile-toggle aria-label="${isLoggedIn ? "Profile options" : "Log in"}">
+      <button class="profile-menu__toggle ${currentUser?.avatarUrl ? "has-avatar" : !isLoggedIn ? "is-wordmark" : ""}" type="button" data-profile-toggle aria-label="${isLoggedIn ? (isAdmin ? "Admin" : "Profile") : "Log in"}">
         <span class="profile-menu__badge ${currentUser?.avatarUrl ? "has-avatar" : !isLoggedIn ? "is-wordmark" : ""}">${profileBadgeMarkup(currentUser)}</span>
         ${unreadCount ? `<span class="profile-menu__notice">${Math.min(unreadCount, 9)}${unreadCount > 9 ? "+" : ""}</span>` : ""}
       </button>
@@ -319,8 +326,7 @@ function renderNavigation() {
                     : ""
                 }
               </div>
-              <a href="./admin.html?tab=profile">Profile options</a>
-              ${isAdmin ? `<a href="./admin.html?tab=dashboard">Admin</a>` : ""}
+              <a href="./admin.html?tab=${isAdmin ? "dashboard" : "profile"}">${isAdmin ? "Admin" : "Profile"}</a>
               <button type="button" data-signout>Sign out</button>
             `
             : `<a href="./admin.html?tab=login">Log in</a>`
@@ -423,6 +429,44 @@ async function initAuthoringEntry() {
     return;
   }
   host.innerHTML = `<a class="button" href="./editor.html">Create investigation</a>`;
+}
+
+async function initStaticPageEditing() {
+  const pageId = document.body.dataset.page || "";
+  if (!STATIC_EDITABLE_PAGES.has(pageId) || state.staticEdit) return;
+  const editableElements = [...document.querySelectorAll("[data-static-edit]")].filter(
+    (node) => node instanceof HTMLElement
+  );
+  if (!editableElements.length) return;
+
+  const publicState = await getPublicState().catch(() => null);
+  if (!publicState || !editorEntryAllowed(publicState)) return;
+
+  const originalContent = collectStaticEditContent(editableElements);
+  const storedSnapshot = loadStaticEditSnapshot(pageId);
+  state.staticEdit = {
+    pageId,
+    elements: editableElements,
+    originalContent,
+    history: [cloneStaticEditContent(storedSnapshot?.content || originalContent)],
+    historyIndex: 0,
+    enabled: false,
+    status: storedSnapshot?.savedAt
+      ? `Local snapshot loaded from ${formatLocalTimestamp(storedSnapshot.savedAt)}.`
+      : "Press Ctrl+Shift+E to edit this page.",
+    savedAt: Number(storedSnapshot?.savedAt || 0),
+    saveState: storedSnapshot?.savedAt ? "saved" : "idle"
+  };
+
+  if (storedSnapshot?.content) {
+    applyStaticEditContent(editableElements, storedSnapshot.content, originalContent);
+  }
+
+  renderStaticEditBar();
+  document.addEventListener("keydown", handleStaticEditShortcut);
+  document.addEventListener("input", handleStaticEditInput, true);
+  document.addEventListener("paste", handleStaticEditPaste, true);
+  document.addEventListener("click", handleStaticEditInteraction, true);
 }
 
 function hydrateArchiveSummaryLinks(posts, publicState) {
@@ -2242,6 +2286,221 @@ async function fetchText(path) {
   return response.text();
 }
 
+function renderStaticEditBar() {
+  const editState = state.staticEdit;
+  if (!editState) return;
+  let bar = document.querySelector("[data-static-edit-bar]");
+  if (!(bar instanceof HTMLElement)) {
+    bar = document.createElement("div");
+    bar.className = "static-edit-bar";
+    bar.setAttribute("data-static-edit-bar", "");
+    document.body.append(bar);
+  }
+  bar.classList.toggle("is-visible", editState.enabled);
+  bar.innerHTML = `
+    <div class="static-edit-bar__copy">
+      <strong>Page edit mode</strong>
+      <span>${escapeHtml(editState.status || "Edit directly on the page.")}</span>
+    </div>
+    <div class="static-edit-bar__actions">
+      <button class="button-ghost static-edit-bar__button" type="button" data-static-edit-revert>Revert</button>
+      <button class="button-ghost static-edit-bar__button" type="button" data-static-edit-undo ${editState.historyIndex > 0 ? "" : "disabled"}>Undo</button>
+      <button class="button-ghost static-edit-bar__button" type="button" data-static-edit-redo ${editState.historyIndex < editState.history.length - 1 ? "" : "disabled"}>Redo</button>
+      <button class="button static-edit-bar__button" type="button" data-static-edit-snapshot>Snapshot</button>
+    </div>
+  `;
+}
+
+function handleStaticEditShortcut(event) {
+  if (!state.staticEdit) return;
+  if (!event.ctrlKey || !event.shiftKey || event.key.toLowerCase() !== "e") return;
+  event.preventDefault();
+  toggleStaticEditMode();
+}
+
+function toggleStaticEditMode(force) {
+  const editState = state.staticEdit;
+  if (!editState) return;
+  const next = typeof force === "boolean" ? force : !editState.enabled;
+  editState.enabled = next;
+  document.body.classList.toggle("is-static-editing", next);
+  for (const element of editState.elements) {
+    element.contentEditable = next ? "true" : "false";
+    element.spellcheck = next;
+    element.classList.toggle("static-edit-target", next);
+  }
+  editState.status = next
+    ? editState.savedAt
+      ? `Editing local snapshot from ${formatLocalTimestamp(editState.savedAt)}.`
+      : "Editing this page directly. Snapshot when ready."
+    : editState.savedAt
+      ? `Local snapshot saved ${formatLocalTimestamp(editState.savedAt)}.`
+      : "Press Ctrl+Shift+E to edit this page.";
+  renderStaticEditBar();
+}
+
+function handleStaticEditInteraction(event) {
+  const editState = state.staticEdit;
+  if (!editState) return;
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+
+  const action = target.closest("[data-static-edit-snapshot], [data-static-edit-undo], [data-static-edit-redo], [data-static-edit-revert]");
+  if (action instanceof HTMLElement) {
+    event.preventDefault();
+    if (action.hasAttribute("data-static-edit-snapshot")) {
+      saveStaticEditSnapshot();
+      return;
+    }
+    if (action.hasAttribute("data-static-edit-undo")) {
+      stepStaticEditHistory(-1);
+      return;
+    }
+    if (action.hasAttribute("data-static-edit-redo")) {
+      stepStaticEditHistory(1);
+      return;
+    }
+    if (action.hasAttribute("data-static-edit-revert")) {
+      revertStaticEditToPublished();
+    }
+    return;
+  }
+
+  if (!editState.enabled) return;
+  const editable = target.closest("[data-static-edit]");
+  if (!(editable instanceof HTMLElement)) return;
+  const link = target.closest("a");
+  if (link) {
+    event.preventDefault();
+  }
+}
+
+function handleStaticEditInput(event) {
+  const editState = state.staticEdit;
+  if (!editState?.enabled) return;
+  const target = event.target;
+  if (!(target instanceof HTMLElement) || !target.matches("[data-static-edit]")) return;
+  queueStaticEditHistory();
+}
+
+function handleStaticEditPaste(event) {
+  const editState = state.staticEdit;
+  if (!editState?.enabled) return;
+  const target = event.target;
+  if (!(target instanceof HTMLElement) || !target.matches("[data-static-edit]")) return;
+  event.preventDefault();
+  const text = event.clipboardData?.getData("text/plain") || "";
+  if (!text) return;
+  document.execCommand("insertText", false, text);
+}
+
+function queueStaticEditHistory() {
+  const editState = state.staticEdit;
+  if (!editState) return;
+  if (editState.historyTimer) window.clearTimeout(editState.historyTimer);
+  editState.historyTimer = window.setTimeout(() => {
+    editState.historyTimer = 0;
+    const nextContent = collectStaticEditContent(editState.elements);
+    const currentContent = editState.history[editState.historyIndex] || editState.originalContent;
+    if (staticEditContentMatches(currentContent, nextContent)) return;
+    editState.history = editState.history.slice(0, editState.historyIndex + 1);
+    editState.history.push(cloneStaticEditContent(nextContent));
+    editState.historyIndex = editState.history.length - 1;
+    editState.saveState = "dirty";
+    editState.status = "Unsaved page edits.";
+    renderStaticEditBar();
+  }, 120);
+}
+
+function stepStaticEditHistory(direction) {
+  const editState = state.staticEdit;
+  if (!editState) return;
+  const nextIndex = editState.historyIndex + direction;
+  if (nextIndex < 0 || nextIndex >= editState.history.length) return;
+  editState.historyIndex = nextIndex;
+  applyStaticEditContent(editState.elements, editState.history[nextIndex], editState.originalContent);
+  editState.saveState = staticEditContentMatches(editState.history[nextIndex], editState.originalContent) ? "idle" : "dirty";
+  editState.status = direction < 0 ? "Undid the last page edit." : "Restored the next page edit.";
+  renderStaticEditBar();
+}
+
+function revertStaticEditToPublished() {
+  const editState = state.staticEdit;
+  if (!editState) return;
+  clearStaticEditSnapshot(editState.pageId);
+  applyStaticEditContent(editState.elements, editState.originalContent, editState.originalContent);
+  editState.history = [cloneStaticEditContent(editState.originalContent)];
+  editState.historyIndex = 0;
+  editState.savedAt = 0;
+  editState.saveState = "idle";
+  editState.status = "Reverted to the published page.";
+  renderStaticEditBar();
+}
+
+function saveStaticEditSnapshot() {
+  const editState = state.staticEdit;
+  if (!editState) return;
+  const content = collectStaticEditContent(editState.elements);
+  const savedAt = Date.now();
+  window.localStorage.setItem(staticEditStorageKey(editState.pageId), JSON.stringify({
+    pageId: editState.pageId,
+    savedAt,
+    content
+  }));
+  editState.savedAt = savedAt;
+  editState.saveState = "saved";
+  editState.status = `Snapshot saved locally at ${formatLocalTimestamp(savedAt)}.`;
+  if (!staticEditContentMatches(editState.history[editState.historyIndex], content)) {
+    editState.history.push(cloneStaticEditContent(content));
+    editState.historyIndex = editState.history.length - 1;
+  }
+  renderStaticEditBar();
+}
+
+function collectStaticEditContent(elements) {
+  return Object.fromEntries(
+    (Array.isArray(elements) ? elements : []).map((element) => [
+      element.getAttribute("data-static-edit") || "",
+      element.innerHTML
+    ])
+  );
+}
+
+function applyStaticEditContent(elements, content, fallback = {}) {
+  for (const element of Array.isArray(elements) ? elements : []) {
+    const key = element.getAttribute("data-static-edit") || "";
+    element.innerHTML = Object.prototype.hasOwnProperty.call(content || {}, key)
+      ? String(content[key] || "")
+      : String(fallback?.[key] || "");
+  }
+}
+
+function loadStaticEditSnapshot(pageId) {
+  try {
+    const raw = window.localStorage.getItem(staticEditStorageKey(pageId));
+    const parsed = raw ? JSON.parse(raw) : null;
+    return parsed && parsed.content ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function clearStaticEditSnapshot(pageId) {
+  window.localStorage.removeItem(staticEditStorageKey(pageId));
+}
+
+function staticEditStorageKey(pageId) {
+  return `${SITE.nostr.storageNamespace}.static-edit.${pageId}`;
+}
+
+function staticEditContentMatches(left, right) {
+  return JSON.stringify(left || {}) === JSON.stringify(right || {});
+}
+
+function cloneStaticEditContent(content) {
+  return JSON.parse(JSON.stringify(content || {}));
+}
+
 function renderError(node, message) {
   if (!node) return;
   node.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
@@ -2298,6 +2557,16 @@ function formatDateTime(unixSeconds) {
     hour: "numeric",
     minute: "2-digit"
   }).format(new Date(unixSeconds * 1000));
+}
+
+function formatLocalTimestamp(value) {
+  if (!value) return "just now";
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit"
+  }).format(new Date(value));
 }
 
 function buildArticleMetaLine(post) {

--- a/styles.css
+++ b/styles.css
@@ -36,6 +36,10 @@ body {
     linear-gradient(180deg, #f2eee9 0%, #e8e1d7 52%, #ebe6df 100%);
 }
 
+body.is-static-editing {
+  padding-bottom: 6rem;
+}
+
 img {
   display: block;
   max-width: 100%;
@@ -2553,6 +2557,78 @@ h3 {
 .loading-state__reload {
   min-height: 2.4rem;
   padding: 0.55rem 0.95rem;
+}
+
+.static-edit-target {
+  transition: background 160ms ease, outline-color 160ms ease;
+}
+
+body.is-static-editing [data-static-edit] {
+  cursor: text;
+  outline: 1px dashed rgba(156, 29, 24, 0.22);
+  outline-offset: 0.18rem;
+  background: rgba(255, 255, 255, 0.32);
+}
+
+body.is-static-editing [data-static-edit]:hover,
+body.is-static-editing [data-static-edit]:focus {
+  outline-color: rgba(156, 29, 24, 0.48);
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.static-edit-bar {
+  position: fixed;
+  left: 50%;
+  bottom: 1rem;
+  z-index: 1800;
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: min(60rem, calc(100vw - 2rem));
+  padding: 0.95rem 1rem;
+  border-radius: 22px;
+  border: 1px solid rgba(18, 18, 18, 0.08);
+  background: rgba(18, 18, 18, 0.92);
+  color: #fbf6ef;
+  box-shadow: 0 24px 50px rgba(18, 18, 18, 0.24);
+  transform: translateX(-50%);
+}
+
+.static-edit-bar.is-visible {
+  display: flex;
+}
+
+.static-edit-bar__copy {
+  display: grid;
+  gap: 0.18rem;
+}
+
+.static-edit-bar__copy strong {
+  font-size: 0.95rem;
+}
+
+.static-edit-bar__copy span {
+  color: rgba(251, 246, 239, 0.78);
+  font-size: 0.9rem;
+}
+
+.static-edit-bar__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.static-edit-bar__button.button-ghost {
+  border-color: rgba(251, 246, 239, 0.18);
+  color: #fbf6ef;
+}
+
+.static-edit-bar__button[disabled] {
+  opacity: 0.42;
+  cursor: default;
 }
 
 .loading-spinner {


### PR DESCRIPTION
## What changed
- simplified the avatar menu so signed-in non-admin users see `Profile`, while admins see `Admin`
- added admin-only in-place editing on `Home` and `About` using `Ctrl+Shift+E`
- added a fixed bottom action bar with `Revert`, `Undo`, `Redo`, and `Snapshot`
- made the page content itself editable instead of switching to input-looking controls
- persisted static page snapshots locally so admins can reload and keep working
- updated the roadmap to reflect that static page editing now exists and the next step is bakedown/review integration

## Verification
- node --check scripts/app.js
- Firefox headless check confirmed:
  - the avatar menu shows `Admin` for the signed-in root account
  - `Ctrl+Shift+E` opens page edit mode on `Home` and `About`
  - snapshot persists across reload on `Home`
  - revert restores the published `Home` hero title

Closes #32
