### PR TITLE
Expand hero editing across public pages

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ The current build is meant to be a practical, low-overhead publishing and coordi
 - Keep improving relay compatibility and degraded-mode behavior so the site remains usable even when some relays are noisy or incomplete.
 - Tighten the Linux pinner setup path into a repeatable install, update, and recovery workflow for non-developer operators.
 - Expand end-to-end browser validation around submissions, moderation, publishing, and comment handling before each release.
-- Route approved Home / About page snapshots into the bakedown path so reviewed page edits are written into the repository snapshot layer instead of living only in relay state and browser storage.
+- Add clearer history and conflict handling when multiple queued edits target the same static page before bakedown, so operators can see what will win and why.
 
 ## Publishing Workflow
 
@@ -18,7 +18,7 @@ The current build is meant to be a practical, low-overhead publishing and coordi
 
 ## Longer Term
 
-- Expand transparent page editing beyond Home and About, and add stronger review/history handling around queued page snapshots.
+- Expand transparent page editing beyond hero sections and add stronger review/history handling around queued page snapshots.
 - Add image handling inside the document editor, including attachment, placement controls (left, right, full width), and markdown-safe storage through the existing blob workflow.
 - Add a navigable entity wiki that can enrich facilities, companies, agencies, and related records with expandable fields, history, clearer cross-links into investigations and the map, and a richer type / class / taxonomy model.
 - Add collaborative editing for drafts so more than one approved user can work on a document without relying only on queued revisions and review handoffs.

--- a/get-involved.html
+++ b/get-involved.html
@@ -30,9 +30,9 @@
     <main>
       <section class="hero">
         <div class="wrap">
-          <div class="eyebrow">Get involved / Donate</div>
-          <h1>Support the records work behind the headlines.</h1>
-          <p class="hero__lede">Support can be practical: help cover records costs, share local knowledge, pass along documents, or help publicize published work.</p>
+          <div class="eyebrow" data-static-edit="get-involved.hero.eyebrow">Get involved / Donate</div>
+          <h1 data-static-edit="get-involved.hero.title">Support the records work behind the headlines.</h1>
+          <p class="hero__lede" data-static-edit="get-involved.hero.lede">Support can be practical: help cover records costs, share local knowledge, pass along documents, or help publicize published work.</p>
         </div>
       </section>
 

--- a/guide.html
+++ b/guide.html
@@ -30,9 +30,9 @@
     <main>
       <section class="hero">
         <div class="wrap">
-          <div class="eyebrow">Instructions / Tutorial</div>
-          <h1>Teach the method, not just the findings.</h1>
-          <p class="hero__lede">This page is meant to become a practical guide for records requests, basic subsidy research, and organizing findings for publication.</p>
+          <div class="eyebrow" data-static-edit="guide.hero.eyebrow">Instructions / Tutorial</div>
+          <h1 data-static-edit="guide.hero.title">Teach the method, not just the findings.</h1>
+          <p class="hero__lede" data-static-edit="guide.hero.lede">This page is meant to become a practical guide for records requests, basic subsidy research, and organizing findings for publication.</p>
         </div>
       </section>
 

--- a/investigations.html
+++ b/investigations.html
@@ -31,9 +31,9 @@
     <main>
       <section class="hero">
         <div class="wrap">
-          <div class="eyebrow">Investigations</div>
-          <h1>Case files, records, and findings.</h1>
-          <p class="hero__lede">Follow published investigations, review-ready submissions, and the record trail behind the work.</p>
+          <div class="eyebrow" data-static-edit="investigations.hero.eyebrow">Investigations</div>
+          <h1 data-static-edit="investigations.hero.title">Case files, records, and findings.</h1>
+          <p class="hero__lede" data-static-edit="investigations.hero.lede">Follow published investigations, review-ready submissions, and the record trail behind the work.</p>
         </div>
       </section>
 

--- a/map.html
+++ b/map.html
@@ -31,9 +31,9 @@
     <main>
       <section class="hero">
         <div class="wrap">
-          <div class="eyebrow">Map</div>
-          <h1>Browse investigations geographically.</h1>
-          <p class="hero__lede">Approved entity entries appear here as an alternate way to move through the archive and any related posts.</p>
+          <div class="eyebrow" data-static-edit="map.hero.eyebrow">Map</div>
+          <h1 data-static-edit="map.hero.title">Browse investigations geographically.</h1>
+          <p class="hero__lede" data-static-edit="map.hero.lede">Approved entity entries appear here as an alternate way to move through the archive and any related posts.</p>
         </div>
       </section>
 

--- a/merch.html
+++ b/merch.html
@@ -30,9 +30,9 @@
     <main>
       <section class="hero">
         <div class="wrap">
-          <div class="eyebrow">Merch</div>
-          <h1>A simple outbound page is enough.</h1>
-          <p class="hero__lede">The first version does not need a native storefront. This page can stay lean and just point people to the external merchandise shop connected to the broader project and YouTube presence.</p>
+          <div class="eyebrow" data-static-edit="merch.hero.eyebrow">Merch</div>
+          <h1 data-static-edit="merch.hero.title">A simple outbound page is enough.</h1>
+          <p class="hero__lede" data-static-edit="merch.hero.lede">The first version does not need a native storefront. This page can stay lean and just point people to the external merchandise shop connected to the broader project and YouTube presence.</p>
         </div>
       </section>
 

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -45,11 +45,17 @@ const ARCHIVE_STATUS_OPTIONS = [
   { value: "posted", label: "Posted" }
 ];
 
-const STATIC_EDITABLE_PAGES = new Set(["home", "about"]);
 const STATIC_PAGE_META = Object.freeze({
   home: { title: "Home page", path: "./index.html" },
-  about: { title: "About page", path: "./about.html" }
+  investigations: { title: "Investigations page", path: "./investigations.html" },
+  guide: { title: "Guide page", path: "./guide.html" },
+  submit: { title: "Submit page", path: "./submit.html" },
+  "get-involved": { title: "Get involved page", path: "./get-involved.html" },
+  about: { title: "About page", path: "./about.html" },
+  merch: { title: "Merch page", path: "./merch.html" },
+  map: { title: "Map page", path: "./map.html" }
 });
+const STATIC_EDITABLE_PAGES = new Set(Object.keys(STATIC_PAGE_META));
 
 const state = {
   session: getStoredSession(),

--- a/scripts/submit.js
+++ b/scripts/submit.js
@@ -113,18 +113,14 @@ async function refreshSubmitPage(force = false) {
 
 function renderSubmitLoading(message) {
   const shell = document.querySelector("[data-submit-shell]");
-  const lede = document.querySelector("[data-submit-lede]");
-  if (lede) lede.textContent = message;
   if (shell) shell.innerHTML = renderLoadingState(message);
 }
 
 function renderSubmitPage() {
   const shell = document.querySelector("[data-submit-shell]");
-  const lede = document.querySelector("[data-submit-lede]");
-  if (!shell || !lede) return;
+  if (!shell) return;
 
   if (!submitState.session) {
-    lede.textContent = "Log in to submit material, track status changes, and keep a private thread attached to each submission.";
     shell.innerHTML = `
       <section class="surface-panel">
         <div class="eyebrow">Log in required</div>
@@ -138,7 +134,6 @@ function renderSubmitPage() {
     return;
   }
 
-  lede.textContent = "Each submission stays attached to your account, with status updates and a message thread once admins reply from the shared inbox.";
   shell.innerHTML = `
     <section class="surface-panel">
       <div class="workspace-list__row">

--- a/submit.html
+++ b/submit.html
@@ -30,9 +30,9 @@
     <main data-submit-page>
       <section class="hero">
         <div class="wrap">
-          <div class="eyebrow">Submit</div>
-          <h1>Share material securely.</h1>
-          <p class="hero__lede" data-submit-lede></p>
+          <div class="eyebrow" data-static-edit="submit.hero.eyebrow">Submit</div>
+          <h1 data-static-edit="submit.hero.title">Share material securely.</h1>
+          <p class="hero__lede" data-static-edit="submit.hero.lede">Share material, documents, or leads through your account so status changes and private follow-up stay attached to the same thread.</p>
         </div>
       </section>
 


### PR DESCRIPTION
## What changed
- extend in-place hero editing to investigations, guide, get involved, map, submit, and merch
- stop the submit flow from overwriting the editable hero lede
- update the roadmap so the next static-page work is clearer conflict and history handling before bakedown

## Validation
- node --check scripts/app.js
- node --check scripts/submit.js
- browser run verified the edit bar plus hero title and lede fields on the edited pages

Closes #36

CC @Aux0x7F