### PR TITLE
Polish login and page edit UX

### DIFF
--- a/about.html
+++ b/about.html
@@ -78,9 +78,9 @@
   <footer class="site-footer">
     <div class="wrap site-footer__grid">
       <div>
-        <div class="eyebrow">The True Cost Project</div>
-        <h3>Investigative publishing for public accountability.</h3>
-        <p>The project exists to make public records work easier to follow, cite, and build on.</p>
+        <div class="eyebrow" data-static-edit="footer.brand.eyebrow">The True Cost Project</div>
+        <h3 data-static-edit="footer.brand.title">Public records. Clear trails. A readable archive.</h3>
+        <p data-static-edit="footer.brand.body">Follow the money, track the entities, and keep the evidence easy to revisit.</p>
       </div>
       <div>
         <h3>Explore</h3>

--- a/admin.html
+++ b/admin.html
@@ -45,9 +45,9 @@
   <footer class="site-footer">
     <div class="wrap site-footer__grid">
       <div>
-        <div class="eyebrow">The True Cost Project</div>
-        <h3>Investigative publishing for public accountability.</h3>
-        <p>Shared accounts, moderation, and review stay here while the public site stays lean.</p>
+        <div class="eyebrow" data-static-edit="footer.brand.eyebrow">The True Cost Project</div>
+        <h3 data-static-edit="footer.brand.title">Public records. Clear trails. A readable archive.</h3>
+        <p data-static-edit="footer.brand.body">Follow the money, track the entities, and keep the evidence easy to revisit.</p>
       </div>
       <div>
         <h3>Explore</h3>

--- a/editor.html
+++ b/editor.html
@@ -46,9 +46,9 @@
   <footer class="site-footer">
     <div class="wrap site-footer__grid">
       <div>
-        <div class="eyebrow">The True Cost Project</div>
-        <h3>Investigative publishing for public accountability.</h3>
-        <p>Drafts stay inside the workflow until they are reviewed and baked into the public archive.</p>
+        <div class="eyebrow" data-static-edit="footer.brand.eyebrow">The True Cost Project</div>
+        <h3 data-static-edit="footer.brand.title">Public records. Clear trails. A readable archive.</h3>
+        <p data-static-edit="footer.brand.body">Follow the money, track the entities, and keep the evidence easy to revisit.</p>
       </div>
       <div>
         <h3>Explore</h3>

--- a/get-involved.html
+++ b/get-involved.html
@@ -101,9 +101,9 @@
   <footer class="site-footer">
     <div class="wrap site-footer__grid">
       <div>
-        <div class="eyebrow">The True Cost Project</div>
-        <h3>Investigative publishing for public accountability.</h3>
-        <p>Support pages should make it obvious what the work costs and how people can help sustain it.</p>
+        <div class="eyebrow" data-static-edit="footer.brand.eyebrow">The True Cost Project</div>
+        <h3 data-static-edit="footer.brand.title">Public records. Clear trails. A readable archive.</h3>
+        <p data-static-edit="footer.brand.body">Follow the money, track the entities, and keep the evidence easy to revisit.</p>
       </div>
       <div>
         <h3>Explore</h3>

--- a/guide.html
+++ b/guide.html
@@ -58,9 +58,9 @@
   <footer class="site-footer">
     <div class="wrap site-footer__grid">
       <div>
-        <div class="eyebrow">The True Cost Project</div>
-        <h3>Investigative publishing for public accountability.</h3>
-        <p>The guide is markdown-backed so it can stay current without requiring a heavier content system.</p>
+        <div class="eyebrow" data-static-edit="footer.brand.eyebrow">The True Cost Project</div>
+        <h3 data-static-edit="footer.brand.title">Public records. Clear trails. A readable archive.</h3>
+        <p data-static-edit="footer.brand.body">Follow the money, track the entities, and keep the evidence easy to revisit.</p>
       </div>
       <div>
         <h3>Explore</h3>

--- a/index.html
+++ b/index.html
@@ -123,9 +123,9 @@
   <footer class="site-footer">
     <div class="wrap site-footer__grid">
       <div>
-        <div class="eyebrow">The True Cost Project</div>
-        <h3>Investigative publishing for public accountability.</h3>
-        <p>The archive is meant to stay readable, searchable, and easy to revisit as the work grows.</p>
+        <div class="eyebrow" data-static-edit="footer.brand.eyebrow">The True Cost Project</div>
+        <h3 data-static-edit="footer.brand.title">Public records. Clear trails. A readable archive.</h3>
+        <p data-static-edit="footer.brand.body">Follow the money, track the entities, and keep the evidence easy to revisit.</p>
       </div>
       <div>
         <h3>Explore</h3>

--- a/investigation.html
+++ b/investigation.html
@@ -84,9 +84,9 @@
   <footer class="site-footer">
     <div class="wrap site-footer__grid">
       <div>
-        <div class="eyebrow">The True Cost Project</div>
-        <h3>Investigative publishing for public accountability.</h3>
-        <p>Each investigation is meant to pair public-facing storytelling with a durable source archive.</p>
+        <div class="eyebrow" data-static-edit="footer.brand.eyebrow">The True Cost Project</div>
+        <h3 data-static-edit="footer.brand.title">Public records. Clear trails. A readable archive.</h3>
+        <p data-static-edit="footer.brand.body">Follow the money, track the entities, and keep the evidence easy to revisit.</p>
       </div>
       <div>
         <h3>Explore</h3>

--- a/investigations.html
+++ b/investigations.html
@@ -54,9 +54,9 @@
   <footer class="site-footer">
     <div class="wrap site-footer__grid">
       <div>
-        <div class="eyebrow">The True Cost Project</div>
-        <h3>Investigative publishing for public accountability.</h3>
-        <p>Case files are designed to be readable for the public and useful for organizers doing follow-up research.</p>
+        <div class="eyebrow" data-static-edit="footer.brand.eyebrow">The True Cost Project</div>
+        <h3 data-static-edit="footer.brand.title">Public records. Clear trails. A readable archive.</h3>
+        <p data-static-edit="footer.brand.body">Follow the money, track the entities, and keep the evidence easy to revisit.</p>
       </div>
       <div>
         <h3>Explore</h3>

--- a/map.html
+++ b/map.html
@@ -56,9 +56,9 @@
   <footer class="site-footer">
     <div class="wrap site-footer__grid">
       <div>
-        <div class="eyebrow">The True Cost Project</div>
-        <h3>Investigative publishing for public accountability.</h3>
-        <p>The map is an alternate table of contents for entities and places tied to published work.</p>
+        <div class="eyebrow" data-static-edit="footer.brand.eyebrow">The True Cost Project</div>
+        <h3 data-static-edit="footer.brand.title">Public records. Clear trails. A readable archive.</h3>
+        <p data-static-edit="footer.brand.body">Follow the money, track the entities, and keep the evidence easy to revisit.</p>
       </div>
       <div>
         <h3>Explore</h3>

--- a/merch.html
+++ b/merch.html
@@ -63,9 +63,9 @@
   <footer class="site-footer">
     <div class="wrap site-footer__grid">
       <div>
-        <div class="eyebrow">The True Cost Project</div>
-        <h3>Investigative publishing for public accountability.</h3>
-        <p>Merch should stay a support path, not the center of the site.</p>
+        <div class="eyebrow" data-static-edit="footer.brand.eyebrow">The True Cost Project</div>
+        <h3 data-static-edit="footer.brand.title">Public records. Clear trails. A readable archive.</h3>
+        <p data-static-edit="footer.brand.body">Follow the money, track the entities, and keep the evidence easy to revisit.</p>
       </div>
       <div>
         <h3>Explore</h3>

--- a/scripts/admin.js
+++ b/scripts/admin.js
@@ -426,14 +426,14 @@ function renderLoginPane() {
       <form class="tip-form" data-login-form>
         <label>
           <span>Username</span>
-          <input name="username" type="text" maxlength="40" placeholder="field-notes" required>
+          <input name="username" type="text" maxlength="40" placeholder="username" required>
         </label>
         <label>
           <span>Password</span>
           <input name="password" type="password" maxlength="120" placeholder="••••••••" required>
         </label>
         <div class="button-row">
-          <button class="button" type="submit">Log in</button>
+          <button class="button" type="submit" data-login-submit>Create/Login</button>
         </div>
         <div class="status-box" data-workspace-status>This site uses your username and password to reopen the same account.</div>
       </form>
@@ -1185,7 +1185,13 @@ function renderChatModal() {
 
 async function handleLogin(form) {
   const status = form.querySelector("[data-workspace-status]");
+  const submitButton = form.querySelector("[data-login-submit]");
   try {
+    setLoginPending(submitButton, true);
+    if (status) {
+      status.textContent = "Opening account...";
+      status.dataset.state = "pending";
+    }
     const formData = new FormData(form);
     const session = await signInWithCredentials(formData.get("username"), formData.get("password"));
     await rebroadcastAccount(session);
@@ -1200,7 +1206,18 @@ async function handleLogin(form) {
       status.textContent = String(error?.message || error || "Login failed.");
       status.dataset.state = "error";
     }
+  } finally {
+    setLoginPending(submitButton, false);
   }
+}
+
+function setLoginPending(button, pending) {
+  if (!(button instanceof HTMLButtonElement)) return;
+  button.disabled = pending;
+  button.dataset.busy = pending ? "yes" : "no";
+  button.innerHTML = pending
+    ? `<span class="loading-spinner" aria-hidden="true"></span><span>Opening account...</span>`
+    : "Create/Login";
 }
 
 async function handleProfileSave(form) {

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -50,12 +50,15 @@ const ARCHIVE_STATUS_OPTIONS = [
 const STATIC_PAGE_META = Object.freeze({
   home: { title: "Home page", path: "./index.html" },
   investigations: { title: "Investigations page", path: "./investigations.html" },
+  investigation: { title: "Investigation page", path: "./investigation.html" },
   guide: { title: "Guide page", path: "./guide.html" },
   submit: { title: "Submit page", path: "./submit.html" },
   "get-involved": { title: "Get involved page", path: "./get-involved.html" },
   about: { title: "About page", path: "./about.html" },
   merch: { title: "Merch page", path: "./merch.html" },
-  map: { title: "Map page", path: "./map.html" }
+  map: { title: "Map page", path: "./map.html" },
+  workspace: { title: "Workspace page", path: "./admin.html" },
+  editor: { title: "Editor page", path: "./editor.html" }
 });
 const STATIC_EDITABLE_PAGES = new Set(Object.keys(STATIC_PAGE_META));
 
@@ -530,6 +533,9 @@ function hydrateArchiveSummaryLinks(posts, publicState) {
   const hosts = [...document.querySelectorAll("[data-archive-summary]")];
   if (!hosts.length) return;
   const publishedCount = Array.isArray(posts) ? posts.length : 0;
+  const activeCount = investigationDrafts(publicState?.drafts || []).length;
+  const investigationCount = publishedCount > 0 ? publishedCount : activeCount;
+  const investigationLabel = publishedCount > 0 ? "Published investigations" : "Active investigations";
   const entities = Array.isArray(publicState?.approvedEntities) ? publicState.approvedEntities : [];
   const mappedCount = entities.filter((entity) => Number.isFinite(entity.lat) && Number.isFinite(entity.lng)).length;
   const locationCount = dedupe(entities.map((entity) => String(entity.location || "").trim()).filter(Boolean)).length;
@@ -538,8 +544,8 @@ function hydrateArchiveSummaryLinks(posts, publicState) {
   ).length;
   const markup = `
     <a class="hero-summary__item" href="./investigations.html">
-      <strong>${publishedCount}</strong>
-      <span>Published investigations</span>
+      <strong>${investigationCount}</strong>
+      <span>${investigationLabel}</span>
     </a>
     <a class="hero-summary__item" href="./map.html#entity-index">
       <strong>${entities.length}</strong>
@@ -2675,6 +2681,7 @@ function queueStaticEditLivePublish() {
       const nextContent = collectStaticEditContent(editState.elements);
       const changed = await overlayState.controller.setContent(nextContent);
       if (changed) {
+        await overlayState.controller.flush?.().catch(() => null);
         overlayState.currentContent = cloneStaticEditContent(nextContent);
       }
     } catch {
@@ -2700,6 +2707,7 @@ function renderStaticEditBar() {
       <span>${escapeHtml(editState.status || "Edit directly on the page.")}</span>
     </div>
     <div class="static-edit-bar__actions">
+      <button class="button-ghost static-edit-bar__button" type="button" data-static-edit-close>Close</button>
       <button class="button-ghost static-edit-bar__button" type="button" data-static-edit-revert>Revert</button>
       <button class="button-ghost static-edit-bar__button" type="button" data-static-edit-undo ${editState.historyIndex > 0 ? "" : "disabled"}>Undo</button>
       <button class="button-ghost static-edit-bar__button" type="button" data-static-edit-redo ${editState.historyIndex < editState.history.length - 1 ? "" : "disabled"}>Redo</button>
@@ -2755,9 +2763,13 @@ function handleStaticEditInteraction(event) {
   const target = event.target;
   if (!(target instanceof Element)) return;
 
-  const action = target.closest("[data-static-edit-snapshot], [data-static-edit-undo], [data-static-edit-redo], [data-static-edit-revert]");
+  const action = target.closest("[data-static-edit-snapshot], [data-static-edit-undo], [data-static-edit-redo], [data-static-edit-revert], [data-static-edit-close]");
   if (action instanceof HTMLElement) {
     event.preventDefault();
+    if (action.hasAttribute("data-static-edit-close")) {
+      cancelStaticEditChanges();
+      return;
+    }
     if (action.hasAttribute("data-static-edit-snapshot")) {
       void saveStaticEditSnapshot();
       return;

--- a/styles.css
+++ b/styles.css
@@ -708,6 +708,17 @@ h3 {
   background: #7c120e;
 }
 
+.button[data-busy="yes"] {
+  pointer-events: none;
+}
+
+.button .loading-spinner {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-color: rgba(255, 248, 245, 0.34);
+  border-top-color: #fff8f5;
+}
+
 .button-dark {
   background: var(--bg-strong);
   color: #fff8f5;

--- a/submit.html
+++ b/submit.html
@@ -45,9 +45,9 @@
   <footer class="site-footer">
     <div class="wrap site-footer__grid">
       <div>
-        <div class="eyebrow">The True Cost Project</div>
-        <h3>Investigative publishing for public accountability.</h3>
-        <p>Tip intake is attached to your account so revisions, status updates, and replies stay grouped together.</p>
+        <div class="eyebrow" data-static-edit="footer.brand.eyebrow">The True Cost Project</div>
+        <h3 data-static-edit="footer.brand.title">Public records. Clear trails. A readable archive.</h3>
+        <p data-static-edit="footer.brand.body">Follow the money, track the entities, and keep the evidence easy to revisit.</p>
       </div>
       <div>
         <h3>Explore</h3>


### PR DESCRIPTION
## Summary
- tighten the login form copy and submit feedback
- add a close control in page edit mode and make live page publishes flush immediately
- normalize the first footer block across the site and make it editable wherever page edit mode is available
- fall back to Active investigations on the home stat rail when there are no published investigations yet

## Validation
- 
ode --check scripts/app.js
- 
ode --check scripts/admin.js
- Firefox headless smoke for Enter-to-submit, submit spinner, page edit close control, editable footer, and the home stat fallback

Closes #42
CC @Aux0x7F