### PR TITLE
Polish mobile nav and archive layout

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -102,6 +102,15 @@ function initNavigation() {
   const nav = document.querySelector("[data-site-nav]");
   if (!nav) return;
 
+  const setNavigationOpen = (open) => {
+    nav.classList.toggle("is-open", open);
+    document.body.classList.toggle("is-nav-open", open);
+    if (toggle) {
+      toggle.classList.toggle("is-open", open);
+      toggle.setAttribute("aria-expanded", String(open));
+    }
+  };
+
   renderNavigation();
 
   if (toggle) {
@@ -114,11 +123,13 @@ function initNavigation() {
       <span class="sr-only">Open navigation</span>
     `;
     toggle.addEventListener("click", () => {
-      const isOpen = nav.classList.toggle("is-open");
-      toggle.classList.toggle("is-open", isOpen);
-      toggle.setAttribute("aria-expanded", String(isOpen));
+      setNavigationOpen(!nav.classList.contains("is-open"));
     });
   }
+
+  window.addEventListener("resize", () => {
+    if (window.innerWidth > 980) setNavigationOpen(false);
+  });
 
   document.addEventListener("click", (event) => {
     const target = event.target;
@@ -178,6 +189,7 @@ function initNavigation() {
       clearSession();
       state.session = null;
       state.viewer = null;
+      setNavigationOpen(false);
       renderNavigation();
       window.location.reload();
       return;
@@ -268,6 +280,55 @@ function renderNavigation() {
     : false;
   const mapEnabled = Boolean(state.publicState?.connected);
   const mapCurrent = NAV_KEYS.map.includes(page);
+  const profileMarkup = isLoggedIn
+    ? `
+      <div class="profile-menu ${NAV_KEYS.workspace.includes(page) ? "is-current" : ""} ${state.profileMenuOpen ? "is-open" : ""}" data-profile-menu>
+        <button class="profile-menu__toggle ${currentUser?.avatarUrl ? "has-avatar" : ""}" type="button" data-profile-toggle aria-label="${isAdmin ? "Admin" : "Profile"}">
+          <span class="profile-menu__badge ${currentUser?.avatarUrl ? "has-avatar" : ""}">${profileBadgeMarkup(currentUser)}</span>
+          ${unreadCount ? `<span class="profile-menu__notice">${Math.min(unreadCount, 9)}${unreadCount > 9 ? "+" : ""}</span>` : ""}
+        </button>
+        <div class="profile-menu__panel">
+          <div class="profile-menu__section">
+            <button class="profile-menu__notification-toggle ${notificationsExpanded ? "is-open" : ""}" type="button" data-notification-toggle>
+              <span class="profile-menu__notification-toggle-copy">
+                <strong>Notifications</strong>
+                <span>${
+                  state.notificationsLoading
+                    ? "Looking up updates"
+                    : unreadCount
+                      ? `${unreadCount} item${unreadCount === 1 ? "" : "s"} waiting`
+                      : "No new updates"
+                }</span>
+              </span>
+              ${unreadCount ? `<span class="profile-menu__inline-badge">${Math.min(unreadCount, 9)}${unreadCount > 9 ? "+" : ""}</span>` : `<span class="profile-menu__inline-badge is-muted">0</span>`}
+            </button>
+            ${
+              notificationsExpanded
+                ? `
+                  <div class="profile-menu__notification-shell">
+                    ${
+                      state.notificationsLoading
+                        ? `<div class="loading-state" role="status" aria-live="polite"><span class="loading-spinner" aria-hidden="true"></span><span>Looking up notifications...</span></div>`
+                        : notifications.length
+                          ? `
+                            <div class="profile-menu__notifications">
+                              ${notifications.map((item) => renderNotificationItem(item)).join("")}
+                            </div>
+                            <button class="profile-menu__clear" type="button" data-clear-notifications>Clear notifications</button>
+                          `
+                          : `<div class="profile-menu__notification-empty">No notifications right now.</div>`
+                    }
+                  </div>
+                `
+                : ""
+            }
+          </div>
+          <a href="./admin.html?tab=${isAdmin ? "dashboard" : "profile"}">${isAdmin ? "Admin" : "Profile"}</a>
+          <button type="button" data-signout>Sign out</button>
+        </div>
+      </div>
+    `
+    : `<a class="profile-cta" href="./admin.html?tab=login" aria-label="Create or log in">Create/Login</a>`;
 
   nav.innerHTML = `
     <a class="${navLinkClass(page, "home")}" href="./index.html">Home</a>
@@ -299,57 +360,7 @@ function renderNavigation() {
     </div>
     <a class="${navLinkClass(page, "about")}" href="./about.html">About</a>
     <a class="${navLinkClass(page, "merch")}" href="./merch.html">Merch</a>
-    <div class="profile-menu ${NAV_KEYS.workspace.includes(page) ? "is-current" : ""} ${state.profileMenuOpen ? "is-open" : ""}" data-profile-menu>
-      <button class="profile-menu__toggle ${currentUser?.avatarUrl ? "has-avatar" : !isLoggedIn ? "is-wordmark" : ""}" type="button" data-profile-toggle aria-label="${isLoggedIn ? (isAdmin ? "Admin" : "Profile") : "Log in"}">
-        <span class="profile-menu__badge ${currentUser?.avatarUrl ? "has-avatar" : !isLoggedIn ? "is-wordmark" : ""}">${profileBadgeMarkup(currentUser)}</span>
-        ${unreadCount ? `<span class="profile-menu__notice">${Math.min(unreadCount, 9)}${unreadCount > 9 ? "+" : ""}</span>` : ""}
-      </button>
-      <div class="profile-menu__panel">
-        ${
-          isLoggedIn
-            ? `
-              <div class="profile-menu__section">
-                <button class="profile-menu__notification-toggle ${notificationsExpanded ? "is-open" : ""}" type="button" data-notification-toggle>
-                  <span class="profile-menu__notification-toggle-copy">
-                    <strong>Notifications</strong>
-                    <span>${
-                      state.notificationsLoading
-                        ? "Looking up updates"
-                        : unreadCount
-                          ? `${unreadCount} item${unreadCount === 1 ? "" : "s"} waiting`
-                          : "No new updates"
-                    }</span>
-                  </span>
-                  ${unreadCount ? `<span class="profile-menu__inline-badge">${Math.min(unreadCount, 9)}${unreadCount > 9 ? "+" : ""}</span>` : `<span class="profile-menu__inline-badge is-muted">0</span>`}
-                </button>
-                ${
-                  notificationsExpanded
-                    ? `
-                      <div class="profile-menu__notification-shell">
-                        ${
-                          state.notificationsLoading
-                            ? `<div class="loading-state" role="status" aria-live="polite"><span class="loading-spinner" aria-hidden="true"></span><span>Looking up notifications...</span></div>`
-                            : notifications.length
-                              ? `
-                                <div class="profile-menu__notifications">
-                                  ${notifications.map((item) => renderNotificationItem(item)).join("")}
-                                </div>
-                                <button class="profile-menu__clear" type="button" data-clear-notifications>Clear notifications</button>
-                              `
-                              : `<div class="profile-menu__notification-empty">No notifications right now.</div>`
-                        }
-                      </div>
-                    `
-                    : ""
-                }
-              </div>
-              <a href="./admin.html?tab=${isAdmin ? "dashboard" : "profile"}">${isAdmin ? "Admin" : "Profile"}</a>
-              <button type="button" data-signout>Sign out</button>
-            `
-            : `<a href="./admin.html?tab=login">Log in</a>`
-        }
-      </div>
-    </div>
+    ${profileMarkup}
   `;
 
   for (const disabled of nav.querySelectorAll('[aria-disabled="true"]')) {
@@ -366,7 +377,7 @@ function profileBadgeMarkup(user) {
       : "";
     return `<img src="${escapeAttribute(user.avatarUrl)}" alt="${escapeAttribute(label)}"${blobAttrs}>`;
   }
-  if (!state.session?.username) return "Log in";
+  if (!state.session?.username) return "Create/Login";
   return escapeHtml(profileInitials(user?.displayName || state.session.username));
 }
 

--- a/styles.css
+++ b/styles.css
@@ -36,6 +36,10 @@ body {
     linear-gradient(180deg, #f2eee9 0%, #e8e1d7 52%, #ebe6df 100%);
 }
 
+body.is-nav-open {
+  overflow: hidden;
+}
+
 body.is-static-editing {
   padding-bottom: 6rem;
 }
@@ -245,6 +249,25 @@ h3 {
 .nav-group,
 .profile-menu {
   position: relative;
+}
+
+.profile-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.8rem;
+  padding: 0.7rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(18, 18, 18, 0.08);
+  background: linear-gradient(135deg, rgba(156, 29, 24, 0.95), rgba(111, 13, 9, 0.95));
+  color: #fff8f5;
+  text-decoration: none;
+  font-weight: 700;
+  transition: transform 120ms ease, opacity 120ms ease;
+}
+
+.profile-cta:hover {
+  transform: translateY(-1px);
 }
 
 .nav-group__panel,
@@ -609,6 +632,7 @@ h3 {
   flex-wrap: wrap;
   gap: 0.8rem;
   margin-top: 1.6rem;
+  align-items: flex-end;
 }
 
 .hero__panel,
@@ -800,12 +824,14 @@ h3 {
 
 .archive-layout {
   display: grid;
+  grid-template-areas: "results rail";
   grid-template-columns: minmax(0, 2fr) minmax(290px, 1fr);
   gap: 1.2rem;
   align-items: start;
 }
 
 .archive-results-shell {
+  grid-area: results;
   grid-column: 1;
   grid-row: 1;
   min-width: 0;
@@ -820,9 +846,11 @@ h3 {
 .archive-filters-shell,
 .archive-map-shell {
   min-width: 0;
+  width: 100%;
 }
 
 .archive-rail-shell {
+  grid-area: rail;
   grid-column: 2;
   grid-row: 1;
   position: sticky;
@@ -1009,6 +1037,7 @@ h3 {
 
 .surface-panel--stacked .button-row {
   margin-top: auto;
+  align-items: flex-end;
 }
 
 .surface-panel--stacked > .button,
@@ -1022,6 +1051,17 @@ h3 {
 .investigation-card,
 .article-card {
   padding: 1.5rem;
+}
+
+.investigation-card--compact {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.investigation-card--compact .text-link {
+  margin-top: auto;
+  align-self: flex-start;
 }
 
 .investigation-card--list {
@@ -2724,8 +2764,11 @@ body.is-static-editing [data-static-edit]:focus {
   }
 
   .archive-layout {
-    display: flex;
-    flex-direction: column;
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "filters"
+      "results"
+      "map";
   }
 
   .archive-rail-shell {
@@ -2734,15 +2777,16 @@ body.is-static-editing [data-static-edit]:focus {
   }
 
   .archive-filters-shell {
-    order: 1;
+    grid-area: filters;
   }
 
   .archive-results-shell {
-    order: 2;
+    grid-area: results;
+    width: 100%;
   }
 
   .archive-map-shell {
-    order: 3;
+    grid-area: map;
   }
 
   .nav-toggle {
@@ -2754,11 +2798,17 @@ body.is-static-editing [data-static-edit]:focus {
     width: 100%;
     margin-left: 0;
     padding-top: 0.4rem;
+    min-height: 0;
   }
 
   .site-nav.is-open {
     display: grid;
     gap: 0.5rem;
+    align-content: start;
+    max-height: calc(100dvh - 5.5rem);
+    overflow: auto;
+    overscroll-behavior: contain;
+    padding-bottom: 1rem;
   }
 
   .editor-actions {
@@ -2797,6 +2847,10 @@ body.is-static-editing [data-static-edit]:focus {
   .profile-menu__toggle.has-avatar {
     width: 100%;
     padding: 0.7rem 1rem;
+  }
+
+  .profile-cta {
+    width: 100%;
   }
 
   .profile-menu__badge.has-avatar {
@@ -2869,5 +2923,18 @@ body.is-static-editing [data-static-edit]:focus {
 
   .archive-filters__form {
     grid-template-columns: 1fr;
+  }
+
+  .hero__actions,
+  .surface-panel .button-row,
+  .quote-card .button-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .hero__actions > *,
+  .surface-panel .button-row > *,
+  .quote-card .button-row > * {
+    width: 100%;
   }
 }


### PR DESCRIPTION
Closes #44\n\n## What changed\n- simplified the logged-out profile area to a single Create/Login action\n- locked background scroll while the mobile drawer is open and let the drawer scroll on its own\n- stacked mobile action rows instead of letting buttons wrap awkwardly\n- tightened the investigations mobile layout so filters, results, and map stay full width and in order\n- kept featured investigation action links pinned to the bottom of their cards\n\n## Validation\n- node --check scripts/app.js\n- mobile Firefox headless check against a local served build