### PR TITLE
Tighten editor live overlay bootstrap

### DIFF
--- a/scripts/editor.js
+++ b/scripts/editor.js
@@ -1010,6 +1010,14 @@ async function ensureLiveInvestigationOverlay() {
     onRemoteContent: handleLiveInvestigationContent,
     onStatus: handleLiveInvestigationStatus,
   });
+  const initialContent = editorState.liveController?.getContent?.() || {};
+  if (Object.keys(initialContent).length) {
+    handleLiveInvestigationContent(initialContent, {
+      documentId,
+      hasLiveContent: true,
+      origin: "initial"
+    });
+  }
 }
 
 function destroyLiveInvestigationOverlay() {


### PR DESCRIPTION
## Summary
- apply the current live investigation unit immediately after the editor connects
- remove the extra settle delay before live state appears in authoring

## Testing
- node --check scripts/editor.js
- browser proof: local editor and detail view synced live and reverted cleanly
