### PR TITLE
Tighten search rails and comment thread handling

### DIFF
--- a/about.html
+++ b/about.html
@@ -68,7 +68,7 @@
             <div class="eyebrow" data-static-edit="about.divein.eyebrow">Dive in</div>
             <h2 data-static-edit="about.divein.title">See what the project is building.</h2>
             <p data-static-edit="about.divein.body">Move from this overview into the archive, the entity index, or the geographic view of the work.</p>
-            <div class="hero-summary hero-summary--light hero-summary--stack" data-archive-summary></div>
+            <div class="hero-summary hero-summary--light hero-summary--duo" data-archive-summary></div>
           </section>
         </div>
       </section>

--- a/scripts/admin.js
+++ b/scripts/admin.js
@@ -44,12 +44,16 @@ const workspaceState = {
   userDirectStatus: "",
   userLookupQuery: "",
   userLookupResult: null,
+  userLookupLoading: false,
+  userLookupRequestId: 0,
+  userLookupDebounce: 0,
   userModalPubkey: "",
   userActionModal: null,
   commentActionModal: null,
   submissionModal: null,
   commentMenuId: "",
   ownCommentMenuId: "",
+  submissionFilterHighlight: -1,
   commentFilters: {
     query: "",
     role: ""
@@ -162,6 +166,7 @@ function bindWorkspace() {
       workspaceState.submissionFilters.query = applySubmissionFilterSuggestion(
         submissionSuggestion.getAttribute("data-submission-filter-suggestion") || ""
       );
+      workspaceState.submissionFilterHighlight = -1;
       renderWorkspace({ soft: true });
       return;
     }
@@ -175,6 +180,29 @@ function bindWorkspace() {
     const directUserAction = target.closest("[data-quick-user-action]");
     if (directUserAction) {
       await handleDirectUserAction(directUserAction);
+      return;
+    }
+
+    const clearUserLookup = target.closest("[data-clear-user-lookup]");
+    if (clearUserLookup) {
+      clearWorkspaceUserLookup();
+      renderWorkspace({ soft: true });
+      return;
+    }
+
+    const clearCommentFilter = target.closest("[data-clear-comment-filter]");
+    if (clearCommentFilter) {
+      workspaceState.commentFilters.query = "";
+      clearWorkspaceLinkedUser();
+      renderWorkspace({ soft: true });
+      return;
+    }
+
+    const clearSubmissionFilter = target.closest("[data-clear-submission-filter]");
+    if (clearSubmissionFilter) {
+      workspaceState.submissionFilters.query = "";
+      workspaceState.submissionFilterHighlight = -1;
+      renderWorkspace({ soft: true });
       return;
     }
 
@@ -285,6 +313,7 @@ function bindWorkspace() {
     }
     if (target.matches("[data-comment-filter-query]")) {
       workspaceState.commentFilters.query = String(target.value || "");
+      clearWorkspaceLinkedUser();
       renderWorkspace({ soft: true });
       return;
     }
@@ -295,6 +324,59 @@ function bindWorkspace() {
     }
     if (target.matches("[data-submission-filter-input]")) {
       workspaceState.submissionFilters.query = String(target.value || "");
+      const suggestions = submissionFilterSuggestions();
+      workspaceState.submissionFilterHighlight = suggestions.length ? 0 : -1;
+      renderWorkspace({ soft: true });
+      return;
+    }
+    if (target.matches("[data-quick-user-input]")) {
+      workspaceState.userLookupRequestId += 1;
+      workspaceState.userLookupQuery = String(target.value || "");
+      workspaceState.userLookupResult = null;
+      workspaceState.userDirectStatus = "";
+      workspaceState.userLookupLoading = Boolean(workspaceState.userLookupQuery.trim());
+      clearWorkspaceLinkedUser();
+      scheduleUserLookup();
+      renderWorkspace({ soft: true });
+    }
+  });
+
+  shell.addEventListener("keydown", async (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    if (target.matches("[data-quick-user-input]") && event.key === "Enter") {
+      event.preventDefault();
+      await handleDirectUserLookup();
+      return;
+    }
+    if (!target.matches("[data-submission-filter-input]")) return;
+    const suggestions = submissionFilterSuggestions();
+    if (event.key === "ArrowDown" && suggestions.length) {
+      event.preventDefault();
+      workspaceState.submissionFilterHighlight = workspaceState.submissionFilterHighlight >= 0
+        ? (workspaceState.submissionFilterHighlight + 1) % suggestions.length
+        : 0;
+      renderWorkspace({ soft: true });
+      return;
+    }
+    if (event.key === "ArrowUp" && suggestions.length) {
+      event.preventDefault();
+      workspaceState.submissionFilterHighlight = workspaceState.submissionFilterHighlight > 0
+        ? workspaceState.submissionFilterHighlight - 1
+        : suggestions.length - 1;
+      renderWorkspace({ soft: true });
+      return;
+    }
+    if (event.key === "Escape") {
+      workspaceState.submissionFilterHighlight = -1;
+      renderWorkspace({ soft: true });
+      return;
+    }
+    if (event.key === "Enter" && suggestions.length) {
+      event.preventDefault();
+      const selected = suggestions[Math.max(0, workspaceState.submissionFilterHighlight)];
+      workspaceState.submissionFilters.query = applySubmissionFilterSuggestion(selected);
+      workspaceState.submissionFilterHighlight = -1;
       renderWorkspace({ soft: true });
     }
   });
@@ -329,6 +411,7 @@ async function refreshWorkspace(force = false) {
   workspaceState.activeTab = chooseInitialTab(workspaceState.activeTab);
   renderWorkspace();
   await maybeResolveUserDeepLink();
+  maybeResolveCommentDeepLink();
   workspaceState.keyRequestState = "";
   void maybeRequestWorkspaceStateRepair(workspaceState.publicState, "workspace-load");
   await maybeAutoRespondToKeyRequests().catch(() => {});
@@ -708,21 +791,7 @@ function renderProfilePane() {
 function renderUsersPane() {
   const visibleUsers = visibleWorkspaceUsers();
   return `
-    <div class="workspace-grid">
-      <section class="surface-panel">
-        <div class="eyebrow">Find user</div>
-        <h2>Lookup by username</h2>
-        <p class="muted-text">Search the shared roster first. If relay state is behind, the direct lookup still checks shared account data in the background.</p>
-        <label class="workspace-search">
-          <span class="sr-only">Username</span>
-          <input class="workspace-search__input" data-quick-user-input type="text" maxlength="80" placeholder="username" value="${escapeAttribute(workspaceState.userLookupQuery || "")}">
-        </label>
-        <div class="button-row button-row--tight">
-          <button class="button" type="button" data-find-user>Find user</button>
-        </div>
-        <div class="status-box">${escapeHtml(workspaceState.userDirectStatus || "Find a user first. Shared site data may take a moment to refresh.")}</div>
-        ${renderLookupCandidate()}
-      </section>
+    <div class="workspace-grid workspace-grid--rail">
       <section class="surface-panel">
         <div class="eyebrow">User Management</div>
         <h2>Shared roster</h2>
@@ -734,6 +803,26 @@ function renderUsersPane() {
           }
         </div>
       </section>
+      <aside class="surface-panel workspace-rail-panel">
+        <div class="eyebrow">Find user</div>
+        <h2>Lookup by username</h2>
+        <label class="workspace-search">
+          <span class="sr-only">Username</span>
+          <input class="workspace-search__input" data-quick-user-input type="text" maxlength="80" placeholder="username" value="${escapeAttribute(workspaceState.userLookupQuery || "")}" autocomplete="off">
+          ${
+            workspaceState.userLookupQuery && !workspaceState.userLookupLoading
+              ? `<button class="workspace-search__clear" type="button" data-clear-user-lookup aria-label="Clear lookup">×</button>`
+              : ""
+          }
+          ${
+            workspaceState.userLookupLoading
+              ? `<span class="workspace-search__spinner" aria-hidden="true"><span class="loading-spinner"></span></span>`
+              : ""
+          }
+        </label>
+        <div class="status-box">${escapeHtml(workspaceState.userDirectStatus || "")}</div>
+        ${renderLookupCandidate()}
+      </aside>
     </div>
   `;
 }
@@ -818,9 +907,7 @@ function renderUserIdentityButton(user, fallbackPubkey = user?.pubkey || "") {
 }
 
 function filterWorkspaceComments(comments) {
-  const params = new URLSearchParams(window.location.search);
-  const deepLinkUser = String(params.get("user") || "").trim().toLowerCase();
-  const query = String(workspaceState.commentFilters.query || deepLinkUser || "").trim().toLowerCase();
+  const query = String(workspaceState.commentFilters.query || "").trim().toLowerCase();
   const role = String(workspaceState.commentFilters.role || "").trim().toLowerCase();
   return (Array.isArray(comments) ? comments : []).filter((comment) => {
     const author = resolveWorkspaceUser(comment.author);
@@ -977,6 +1064,8 @@ function renderCommentActionModal() {
           ${
             modal.mode === "edit"
               ? `<label><span>Comment</span><textarea name="markdown" required>${escapeHtml(comment.markdown || "")}</textarea></label>`
+              : modal.mode === "delete"
+                ? `<p class="muted-text">Deleting your comment also removes its replies from the public thread.</p>`
               : ""
           }
           ${
@@ -1123,10 +1212,14 @@ function renderSubmissionsPane() {
               value="${escapeAttribute(workspaceState.submissionFilters.query || "")}"
               autocomplete="off"
             >
+            ${
+              workspaceState.submissionFilters.query
+                ? `<button class="workspace-search__clear" type="button" data-clear-submission-filter aria-label="Clear submission filters">×</button>`
+                : ""
+            }
             ${filterSuggestions}
           </label>
         </div>
-        <div class="muted-text">Use comma-separated filters like <span class="mono">status:confirmed</span>, <span class="mono">user:username</span>, <span class="mono">type:pdf</span>, <span class="mono">location:phoenix</span>, or <span class="mono">entity:county line</span>.</div>
         <div class="roster-list">
           ${
             workspaceState.inboxLoading
@@ -1453,7 +1546,6 @@ function reviewedDraftAction(draft) {
 
 function renderCommentsPane() {
   const ownComments = workspaceState.publicState?.commentsByAuthor.get(workspaceState.viewer?.pubkey || "") || [];
-  const linkedUser = String(new URLSearchParams(window.location.search).get("user") || "").trim();
   if (currentUserIsAdmin()) {
     const allComments = filterWorkspaceComments((workspaceState.publicState?.allComments || []).slice().reverse());
     const hiddenCount = workspaceState.publicState?.hiddenComments?.length || 0;
@@ -1472,7 +1564,12 @@ function renderCommentsPane() {
         <div class="workspace-filter-bar">
           <label class="workspace-search">
             <span class="sr-only">Search comments</span>
-            <input class="workspace-search__input" data-comment-filter-query type="text" maxlength="120" placeholder="Search comments or users" value="${escapeAttribute(workspaceState.commentFilters.query || linkedUser)}">
+            <input class="workspace-search__input" data-comment-filter-query type="text" maxlength="120" placeholder="Search comments or users" value="${escapeAttribute(workspaceState.commentFilters.query || "")}" autocomplete="off">
+            ${
+              workspaceState.commentFilters.query
+                ? `<button class="workspace-search__clear" type="button" data-clear-comment-filter aria-label="Clear comment search">×</button>`
+                : ""
+            }
           </label>
           <label class="workspace-select">
             <span class="sr-only">Filter by role</span>
@@ -1816,6 +1913,10 @@ async function handleDirectUserAction(button) {
 }
 
 async function handleDirectUserLookup() {
+  if (workspaceState.userLookupDebounce) {
+    window.clearTimeout(workspaceState.userLookupDebounce);
+    workspaceState.userLookupDebounce = 0;
+  }
   const input = document.querySelector("[data-quick-user-input]");
   const rawValue = String(input instanceof HTMLInputElement ? input.value : workspaceState.userLookupQuery || "").trim();
   await resolveUserLookupQuery(rawValue);
@@ -1823,36 +1924,41 @@ async function handleDirectUserLookup() {
 
 async function resolveUserLookupQuery(rawValue, options = {}) {
   const shouldRender = options.render !== false;
-  workspaceState.userLookupQuery = rawValue;
+  const cleanValue = String(rawValue || "").trim();
+  const requestId = workspaceState.userLookupRequestId + 1;
+  workspaceState.userLookupRequestId = requestId;
+  workspaceState.userLookupQuery = cleanValue;
   workspaceState.userLookupResult = null;
-  if (!rawValue) {
-    workspaceState.userDirectStatus = "Enter a username.";
-    if (shouldRender) renderWorkspace();
+  workspaceState.userLookupLoading = false;
+  if (!cleanValue) {
+    workspaceState.userDirectStatus = "";
+    if (shouldRender) renderWorkspace({ soft: true });
     return;
   }
 
-  const localMatch = findLocalUserCandidate(rawValue);
+  const localMatch = findLocalUserCandidate(cleanValue);
   if (localMatch) {
-    workspaceState.userLookupQuery = localMatch.pubkey;
     workspaceState.userLookupResult = localMatch;
     workspaceState.userDirectStatus = `Found ${localMatch.username ? `@${localMatch.username}` : localMatch.displayName || "this user"} in the current roster.`;
-    if (shouldRender) renderWorkspace();
+    if (shouldRender) renderWorkspace({ soft: true });
     return;
   }
 
-  const remoteMatches = await lookupUsers(rawValue).catch(() => []);
+  workspaceState.userLookupLoading = true;
+  if (shouldRender) renderWorkspace({ soft: true });
+  const remoteMatches = await lookupUsers(cleanValue).catch(() => []);
+  if (requestId !== workspaceState.userLookupRequestId) return;
+  workspaceState.userLookupLoading = false;
   if (remoteMatches.length) {
     const match = hydrateLookupCandidate(remoteMatches[0]);
-    workspaceState.userLookupQuery = match.pubkey;
     workspaceState.userLookupResult = match;
     workspaceState.userDirectStatus = `Found ${match.username ? `@${match.username}` : match.displayName || "this user"} from shared site data.`;
-    if (shouldRender) renderWorkspace();
+    if (shouldRender) renderWorkspace({ soft: true });
     return;
   }
 
-  const directPubkey = normalizeDirectPubkey(rawValue);
+  const directPubkey = normalizeDirectPubkey(cleanValue);
   if (directPubkey) {
-    workspaceState.userLookupQuery = directPubkey;
     workspaceState.userLookupResult = hydrateLookupCandidate({
       pubkey: directPubkey,
       username: "",
@@ -1860,12 +1966,41 @@ async function resolveUserLookupQuery(rawValue, options = {}) {
       isAdmin: workspaceState.publicState?.admins?.includes(directPubkey)
     });
     workspaceState.userDirectStatus = "No profile is visible yet, but this account can still be managed directly.";
-    if (shouldRender) renderWorkspace();
+    if (shouldRender) renderWorkspace({ soft: true });
     return;
   }
 
   workspaceState.userDirectStatus = "No matching user found yet.";
-  if (shouldRender) renderWorkspace();
+  if (shouldRender) renderWorkspace({ soft: true });
+}
+
+function scheduleUserLookup() {
+  if (workspaceState.userLookupDebounce) {
+    window.clearTimeout(workspaceState.userLookupDebounce);
+    workspaceState.userLookupDebounce = 0;
+  }
+  const query = String(workspaceState.userLookupQuery || "").trim();
+  if (!query) {
+    workspaceState.userLookupLoading = false;
+    return;
+  }
+  workspaceState.userLookupDebounce = window.setTimeout(() => {
+    workspaceState.userLookupDebounce = 0;
+    void resolveUserLookupQuery(query);
+  }, 260);
+}
+
+function clearWorkspaceUserLookup() {
+  if (workspaceState.userLookupDebounce) {
+    window.clearTimeout(workspaceState.userLookupDebounce);
+    workspaceState.userLookupDebounce = 0;
+  }
+  workspaceState.userLookupRequestId += 1;
+  workspaceState.userLookupQuery = "";
+  workspaceState.userLookupResult = null;
+  workspaceState.userLookupLoading = false;
+  workspaceState.userDirectStatus = "";
+  clearWorkspaceLinkedUser();
 }
 
 async function performUserAction(targetPubkey, action, mode = "") {
@@ -2255,8 +2390,7 @@ async function markSubmissionViewed(submissionId) {
 }
 
 async function maybeResolveUserDeepLink() {
-  const params = new URLSearchParams(window.location.search);
-  const query = String(params.get("user") || "").trim();
+  const query = readWorkspaceLinkedUser();
   if (!query || workspaceState.activeTab !== "users") return;
   if (workspaceState.userLookupQuery !== query || !workspaceState.userLookupResult) {
     await resolveUserLookupQuery(query, { render: false });
@@ -2270,6 +2404,23 @@ async function maybeResolveUserDeepLink() {
     card.classList.add("roster-item--focus");
     window.setTimeout(() => card.classList.remove("roster-item--focus"), 1800);
   }
+}
+
+function maybeResolveCommentDeepLink() {
+  const query = readWorkspaceLinkedUser();
+  if (!query || workspaceState.activeTab !== "comments" || workspaceState.commentFilters.query) return;
+  workspaceState.commentFilters.query = query;
+  renderWorkspace({ soft: true });
+}
+
+function readWorkspaceLinkedUser() {
+  return String(new URLSearchParams(window.location.search).get("user") || "").trim();
+}
+
+function clearWorkspaceLinkedUser() {
+  const url = new URL(window.location.href);
+  url.searchParams.delete("user");
+  history.replaceState({}, "", url);
 }
 
 async function handleChatSend(form) {
@@ -2433,6 +2584,9 @@ function setActiveTab(tab) {
   workspaceState.activeTab = normalizeWorkspaceTab(tab);
   const url = new URL(window.location.href);
   url.searchParams.set("tab", workspaceState.activeTab);
+  if (!["users", "comments"].includes(workspaceState.activeTab)) {
+    url.searchParams.delete("user");
+  }
   history.replaceState({}, "", url);
 }
 
@@ -2682,13 +2836,18 @@ function renderSubmissionFilterSuggestions() {
   const suggestions = submissionFilterSuggestions();
   if (!suggestions.length) return "";
   return `
-    <div class="picker-results picker-results--dropdown archive-filters__results" data-open="yes">
+    <div class="picker-results picker-results--dropdown workspace-search__results" data-open="yes">
       ${suggestions
         .map(
-          (token) => `
-            <button class="picker-chip" type="button" data-submission-filter-suggestion="${escapeAttribute(token)}">
+          (token, index) => `
+            <button
+              class="picker-chip${workspaceState.submissionFilterHighlight === index ? " is-highlighted" : ""}"
+              type="button"
+              data-submission-filter-suggestion="${escapeAttribute(token)}"
+              data-submission-filter-index="${index}"
+              aria-selected="${workspaceState.submissionFilterHighlight === index ? "true" : "false"}"
+            >
               <strong>${escapeHtml(token)}</strong>
-              <span>Use filter</span>
             </button>
           `
         )
@@ -2700,6 +2859,7 @@ function renderSubmissionFilterSuggestions() {
 function submissionFilterSuggestions() {
   const raw = String(workspaceState.submissionFilters.query || "");
   const segment = raw.split(",").pop()?.trim().toLowerCase() || "";
+  if (!segment) return [];
   const suggestionPool = [
     "status:confirmed",
     "status:unconfirmed",
@@ -3035,7 +3195,6 @@ function findLocalUserCandidate(value) {
 }
 
 function visibleWorkspaceUsers() {
-  const query = String(workspaceState.userLookupQuery || "").trim().toLowerCase();
   return (workspaceState.publicState?.users || []).filter((user) => {
     const visible =
       user.isAdmin ||
@@ -3047,18 +3206,7 @@ function visibleWorkspaceUsers() {
       (Array.isArray(user.socialLinks) && user.socialLinks.length) ||
       user.avatarUrl ||
       user.avatarBlob;
-    if (!visible) return false;
-    if (!query) return true;
-    const haystacks = [
-      user.pubkey,
-      user.username,
-      user.displayName,
-      user.bio,
-      ...(Array.isArray(user.socialLinks) ? user.socialLinks : [])
-    ]
-      .map((value) => String(value || "").trim().toLowerCase())
-      .filter(Boolean);
-    return haystacks.some((value) => value.includes(query));
+    return visible;
   });
 }
 

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -104,6 +104,7 @@ const state = {
 document.addEventListener("DOMContentLoaded", () => {
   initExternalLinks();
   initNavigation();
+  initLinkPrefetch();
   bindGlobalSiteInteractions();
   initInvestigationCards();
   void initInvestigationDetail();
@@ -312,20 +313,53 @@ function startBackgroundPrefetch() {
       "./about.html",
       "./guide.html",
       "./submit.html",
+      "./get-involved.html",
+      "./merch.html",
+      "./investigation.html",
+      "./editor.html",
       "./admin.html?tab=login"
     ];
     for (const route of routes) {
       fetch(route, { cache: "force-cache" }).catch(() => null);
     }
     fetch("./content/investigations/index.json", { cache: "force-cache" }).catch(() => null);
+    fetch("./content/pages/guide.md", { cache: "force-cache" }).catch(() => null);
+    fetch("./vendor/leaflet.js", { cache: "force-cache" }).catch(() => null);
+    fetch("./vendor/leaflet.css", { cache: "force-cache" }).catch(() => null);
     void loadPosts().catch(() => []);
     void warmPublicState().catch(() => null);
+    if (state.session?.secretKeyHex) {
+      void loadUserSubmissions(state.session.secretKeyHex).catch(() => []);
+      void loadAdminKeyShare(state.session.secretKeyHex).catch(() => null);
+    }
   };
   if (typeof window.requestIdleCallback === "function") {
     window.requestIdleCallback(task, { timeout: 1800 });
     return;
   }
   window.setTimeout(task, 900);
+}
+
+function initLinkPrefetch() {
+  const prefetched = new Set();
+  const maybePrefetch = (value) => {
+    try {
+      const url = new URL(value, window.location.href);
+      if (url.origin !== window.location.origin || prefetched.has(url.href)) return;
+      prefetched.add(url.href);
+      fetch(url.href, { cache: "force-cache" }).catch(() => null);
+    } catch {
+      return;
+    }
+  };
+  const primeTarget = (target) => {
+    if (!(target instanceof Element)) return;
+    const link = target.closest("a[href]");
+    if (!(link instanceof HTMLAnchorElement)) return;
+    maybePrefetch(link.href);
+  };
+  document.addEventListener("pointerover", (event) => primeTarget(event.target), { passive: true });
+  document.addEventListener("focusin", (event) => primeTarget(event.target));
 }
 
 function handleSessionChanged() {
@@ -1217,6 +1251,34 @@ async function renderComments(postSlug, publicState) {
     });
   }
 
+  for (const button of panel.querySelectorAll("[data-delete-comment]")) {
+    button.addEventListener("click", async () => {
+      if (!state.session?.secretKeyHex || !viewerPubkey) return;
+      const commentId = String(button.getAttribute("data-delete-comment") || "").trim();
+      const targetComment = comments.find((comment) => comment.id === commentId);
+      if (!targetComment || targetComment.author !== viewerPubkey) return;
+      if (!window.confirm("Delete this comment and its replies?")) return;
+      try {
+        button.disabled = true;
+        applyLocalCommentDeletion(commentId, "Deleted by author");
+        await renderComments(postSlug, state.publicState);
+        await publishTaggedJson({
+          kind: SITE.nostr.kinds.commentMod,
+          secretKeyHex: state.session.secretKeyHex,
+          tags: [["e", commentId], ["op", "hide"]],
+          content: {
+            target_id: commentId,
+            action: "hide",
+            note: "Deleted by author"
+          }
+        });
+      } catch {
+        state.publicState = await loadPublicState(true).catch(() => state.publicState);
+        await renderComments(postSlug, state.publicState);
+      }
+    });
+  }
+
   for (const button of panel.querySelectorAll("[data-comment-vote]")) {
     button.addEventListener("click", async () => {
       if (!state.session?.secretKeyHex || !viewerPubkey) return;
@@ -1261,6 +1323,7 @@ function renderComment(comment, publicState, options = {}, depth = 0) {
   const replies = Array.isArray(comment.replies) ? comment.replies : [];
   const voteSummary = resolveCommentVoteSummary(publicState, comment.id);
   const viewerVote = options.viewerPubkey ? resolveCurrentVoteForComment(publicState, comment.id, options.viewerPubkey) : 0;
+  const canDelete = Boolean(options.viewerPubkey) && comment.author === options.viewerPubkey;
   const replyForm = options.canReply && options.replyTargetId === comment.id
     ? renderInlineReplyForm(comment, publicState)
     : "";
@@ -1302,6 +1365,7 @@ function renderComment(comment, publicState, options = {}, depth = 0) {
             </div>
             <div class="comment-card__actions">
               ${options.canReply ? `<button type="button" class="button-ghost" data-reply-comment="${escapeAttribute(comment.id)}">Reply</button>` : ""}
+              ${canDelete ? `<button type="button" class="button-ghost" data-delete-comment="${escapeAttribute(comment.id)}">Delete</button>` : ""}
               ${options.isAdmin ? `<button type="button" class="button-ghost" data-hide-comment="${escapeAttribute(comment.id)}">Hide</button>` : ""}
             </div>
           </div>
@@ -1725,6 +1789,42 @@ function appendLocalComment(postSlug, comment) {
   }
 }
 
+function applyLocalCommentDeletion(commentId, note = "Deleted by author") {
+  if (!state.publicState?.allComments) return;
+  const branchIds = collectCommentBranchIds(state.publicState.allComments, commentId);
+  if (!branchIds.length) return;
+  const branchSet = new Set(branchIds);
+  const moderation = {
+    action: "hide",
+    note: String(note || "").trim(),
+    updated_at: Math.floor(Date.now() / 1000),
+    by: state.viewer?.pubkey || ""
+  };
+  const nextComments = (state.publicState.allComments || []).map((comment) => {
+    if (!branchSet.has(String(comment.id || "").trim())) return comment;
+    return {
+      ...comment,
+      visibility: "hidden",
+      moderation:
+        String(comment.id || "").trim() === String(commentId || "").trim()
+          ? moderation
+          : comment.moderation || moderation
+    };
+  });
+  state.publicState.allComments = nextComments;
+  state.publicState.comments = nextComments.filter((comment) => String(comment.visibility || "visible") !== "hidden");
+  state.publicState.hiddenComments = nextComments.filter((comment) => String(comment.visibility || "visible") === "hidden");
+  state.publicState.commentsByPost = regroupComments(state.publicState.comments, "post_slug");
+  state.publicState.commentsByAuthor = regroupComments(state.publicState.comments, "author");
+  for (const user of state.publicState.users || []) {
+    user.commentCount = (state.publicState.commentsByAuthor.get(user.pubkey) || []).length;
+  }
+  if (state.publicState.metrics) {
+    state.publicState.metrics.commentCount = state.publicState.comments.length;
+    state.publicState.metrics.hiddenCommentCount = state.publicState.hiddenComments.length;
+  }
+}
+
 function dedupeCommentList(comments) {
   const seen = new Set();
   return (Array.isArray(comments) ? comments : []).filter((comment) => {
@@ -1733,6 +1833,41 @@ function dedupeCommentList(comments) {
     seen.add(id);
     return true;
   });
+}
+
+function collectCommentBranchIds(comments, rootId) {
+  const children = new Map();
+  for (const comment of Array.isArray(comments) ? comments : []) {
+    const parentId = String(comment?.parent_id || "").trim();
+    const commentId = String(comment?.id || "").trim();
+    if (!parentId || !commentId) continue;
+    const bucket = children.get(parentId) || [];
+    bucket.push(commentId);
+    children.set(parentId, bucket);
+  }
+  const ids = [];
+  const stack = [String(rootId || "").trim()];
+  const seen = new Set();
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current || seen.has(current)) continue;
+    seen.add(current);
+    ids.push(current);
+    for (const childId of children.get(current) || []) stack.push(childId);
+  }
+  return ids;
+}
+
+function regroupComments(comments, key) {
+  const buckets = new Map();
+  for (const comment of Array.isArray(comments) ? comments : []) {
+    const bucketKey = String(comment?.[key] || "").trim();
+    if (!bucketKey) continue;
+    const bucket = buckets.get(bucketKey) || [];
+    bucket.push(comment);
+    buckets.set(bucketKey, bucket);
+  }
+  return buckets;
 }
 
 function renderArchiveMapPanel() {
@@ -2123,8 +2258,15 @@ function renderLeafletPreviewMap(canvas, entities) {
     }).addTo(markers);
     marker.bindTooltip(escapeHtml(entity.name), { direction: "top", opacity: 0.92 });
   }
-  if (points.length) previewMap.fitBounds(points, { padding: [28, 28] });
-  else previewMap.setView(SITE.map.defaultCenter, SITE.map.defaultZoom);
+  if (points.length) {
+    if (typeof previewMap.flyToBounds === "function") {
+      previewMap.flyToBounds(points, { padding: [28, 28], duration: 0.4 });
+    } else {
+      previewMap.fitBounds(points, { padding: [28, 28] });
+    }
+  } else {
+    previewMap.setView(SITE.map.defaultCenter, SITE.map.defaultZoom);
+  }
   window.setTimeout(() => previewMap.invalidateSize(), 60);
 }
 
@@ -2963,7 +3105,11 @@ function renderLeafletMap(canvas, entities) {
   }
 
   if (points.length) {
-    state.map.fitBounds(points, { padding: [40, 40] });
+    if (typeof state.map.flyToBounds === "function") {
+      state.map.flyToBounds(points, { padding: [40, 40], duration: 0.45 });
+    } else {
+      state.map.fitBounds(points, { padding: [40, 40] });
+    }
   } else {
     state.map.setView(SITE.map.defaultCenter, SITE.map.defaultZoom);
   }

--- a/scripts/core/nostr.js
+++ b/scripts/core/nostr.js
@@ -139,17 +139,21 @@ function applyAuthorCommentModeration(publicState) {
   }
   if (!authorModeration.size) return publicState;
 
-  const nextComments = allComments.map((comment) => {
+  const resolvedComments = allComments.map((comment) => {
     const moderation = authorModeration.get(String(comment.id || "").trim());
-    if (!moderation) return comment;
+    if (!moderation) return { ...comment };
     return {
       ...comment,
       visibility: moderation.action === "hide" ? "hidden" : "visible",
       moderation
     };
   });
-  const visibleComments = nextComments.filter((comment) => comment.visibility !== "hidden");
-  const hiddenComments = nextComments.filter((comment) => comment.visibility === "hidden");
+  const nextCommentsById = new Map(resolvedComments.map((comment) => [String(comment.id || "").trim(), comment]));
+  const visibleComments = resolvedComments.filter((comment) => {
+    const branch = collectCommentAncestors(String(comment.id || "").trim(), nextCommentsById);
+    return branch.every((branchComment) => String(branchComment?.visibility || "visible") !== "hidden");
+  });
+  const hiddenComments = resolvedComments.filter((comment) => !visibleComments.includes(comment));
   const commentsByPost = regroupComments(visibleComments, "post_slug");
   const commentsByAuthor = regroupComments(visibleComments, "author");
   const users = Array.isArray(publicState.users)
@@ -161,7 +165,7 @@ function applyAuthorCommentModeration(publicState) {
   return {
     ...publicState,
     users,
-    allComments: nextComments,
+    allComments: resolvedComments,
     comments: visibleComments,
     hiddenComments,
     commentsByPost,
@@ -336,6 +340,21 @@ function regroupComments(comments, key) {
     buckets.set(bucketKey, bucket);
   }
   return buckets;
+}
+
+function collectCommentAncestors(commentId, commentsById) {
+  const lineage = [];
+  let current = commentsById.get(commentId) || null;
+  const seen = new Set();
+  while (current) {
+    const currentId = String(current.id || "").trim();
+    if (!currentId || seen.has(currentId)) break;
+    seen.add(currentId);
+    lineage.push(current);
+    const parentId = String(current.parent_id || "").trim();
+    current = parentId ? commentsById.get(parentId) || null : null;
+  }
+  return lineage;
 }
 
 function firstTag(event, key) {

--- a/styles.css
+++ b/styles.css
@@ -840,6 +840,8 @@ h3 {
 .story-list__results {
   display: grid;
   gap: 1rem;
+  min-height: 24rem;
+  align-content: start;
 }
 
 .archive-rail-shell,
@@ -910,13 +912,14 @@ h3 {
 
 .workspace-search {
   display: grid;
+  position: relative;
 }
 
 .archive-filters__field input,
 .workspace-search__input {
   width: 100%;
   min-height: 3.35rem;
-  padding: 0.95rem 1rem;
+  padding: 0.95rem 3.25rem 0.95rem 1rem;
   border-radius: 18px;
   border: 1px solid var(--line);
   background: rgba(255, 255, 255, 0.82);
@@ -936,6 +939,55 @@ h3 {
   left: 0;
   right: 0;
   z-index: 30;
+}
+
+.workspace-search__results {
+  margin-top: 0;
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  right: 0;
+  z-index: 36;
+}
+
+.workspace-search__clear,
+.workspace-search__spinner {
+  position: absolute;
+  top: 50%;
+  right: 0.85rem;
+  transform: translateY(-50%);
+}
+
+.workspace-search__clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(18, 18, 18, 0.06);
+  color: var(--ink-soft);
+  font: inherit;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.workspace-search__clear:hover,
+.workspace-search__clear:focus-visible {
+  background: rgba(18, 18, 18, 0.1);
+  color: var(--ink);
+  outline: none;
+}
+
+.workspace-search__spinner {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  pointer-events: none;
 }
 
 .archive-status-menu {
@@ -1023,6 +1075,8 @@ h3 {
 .archive-map-card {
   display: grid;
   gap: 0.9rem;
+  min-height: 20rem;
+  align-content: start;
 }
 
 .archive-map-card__tags {
@@ -1318,6 +1372,10 @@ h3 {
   grid-template-columns: repeat(2, minmax(18rem, 30rem));
   justify-content: center;
   align-items: stretch;
+}
+
+.hero-summary--duo {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .support-grid--feature {
@@ -2020,6 +2078,8 @@ h3 {
   display: grid;
   gap: 0.8rem;
   margin-top: 1rem;
+  min-height: 12rem;
+  align-content: start;
 }
 
 .roster-item {
@@ -2203,6 +2263,20 @@ h3 {
   gap: 1.2rem;
 }
 
+.workspace-grid--rail {
+  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+}
+
+.workspace-pane {
+  min-height: 24rem;
+}
+
+.workspace-rail-panel {
+  position: sticky;
+  top: 6rem;
+  align-self: start;
+}
+
 .workspace-filter-bar {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -2339,6 +2413,11 @@ h3 {
   font-size: 0.95rem;
 }
 
+.picker-chip.is-highlighted {
+  background: rgba(156, 29, 24, 0.08);
+  border-color: rgba(156, 29, 24, 0.2);
+}
+
 .picker-create {
   display: flex;
   align-items: center;
@@ -2410,6 +2489,8 @@ h3 {
   display: grid;
   gap: 0.9rem;
   margin-top: 1rem;
+  min-height: 10rem;
+  align-content: start;
 }
 
 .chat-message,
@@ -3011,6 +3092,10 @@ body.is-static-editing [data-static-edit]:focus {
     grid-template-columns: 1fr;
   }
 
+  .hero-summary--duo {
+    grid-template-columns: 1fr;
+  }
+
   .archive-rail {
     position: static;
     top: auto;
@@ -3139,6 +3224,11 @@ body.is-static-editing [data-static-edit]:focus {
 
   .workspace-grid {
     grid-template-columns: 1fr;
+  }
+
+  .workspace-rail-panel {
+    position: static;
+    top: auto;
   }
 
   .workspace-filter-bar {


### PR DESCRIPTION
## Summary
- move user lookup into a right rail, keep search focus stable, and add inline clear/spinner treatment
- anchor submission suggestions to the filter input with keyboard selection and clear the sticky comment deep-link state cleanly
- preserve more layout during loading, warm more page/state data, smooth map fit behavior, and cascade author comment deletes through replies

## Testing
- node --check scripts/app.js
- node --check scripts/admin.js
- node --check scripts/core/nostr.js
- Firefox headless local pass covering user lookup focus retention, comment-filter URL clearing, submission suggestion anchoring/keyboard selection, and about-page archive stat layout

Closes #58