### PR TITLE
Tighten rails and comment thread rendering

### DIFF
--- a/scripts/admin.js
+++ b/scripts/admin.js
@@ -56,6 +56,8 @@ const workspaceState = {
   ownCommentMenuId: "",
   submissionFilterHighlight: -1,
   submissionFilterOpen: false,
+  entityLocationFilterHighlight: -1,
+  entityLocationFilterOpen: false,
   userFilters: {
     karma: ""
   },
@@ -232,9 +234,21 @@ function bindWorkspace() {
       const field = clearEntityFilter.getAttribute("data-clear-entity-filter") || "";
       if (field && Object.prototype.hasOwnProperty.call(workspaceState.entityFilters, field)) {
         workspaceState.entityFilters[field] = "";
+        if (field === "location") {
+          workspaceState.entityLocationFilterHighlight = -1;
+          workspaceState.entityLocationFilterOpen = false;
+        }
         renderWorkspace({ soft: true });
         focusWorkspaceSearchField(`[data-entity-filter-${field}]`);
       }
+      return;
+    }
+
+    const entityLocationSuggestion = target.closest("[data-entity-location-suggestion]");
+    if (entityLocationSuggestion) {
+      applyEntityLocationSuggestion(entityLocationSuggestion.getAttribute("data-entity-location-suggestion") || "");
+      renderWorkspace({ soft: true });
+      focusWorkspaceSearchField("[data-entity-filter-location]");
       return;
     }
 
@@ -334,17 +348,35 @@ function bindWorkspace() {
         workspaceState.submissionFilterOpen = nextOpen;
         renderWorkspace({ soft: true });
       }
+      return;
+    }
+    if (target.matches("[data-entity-filter-location]")) {
+      const nextOpen = Boolean(String(target.value || "").trim() && entityLocationFilterSuggestions().length);
+      if (workspaceState.entityLocationFilterOpen !== nextOpen) {
+        workspaceState.entityLocationFilterOpen = nextOpen;
+        workspaceState.entityLocationFilterHighlight = nextOpen ? 0 : -1;
+        renderWorkspace({ soft: true });
+      }
     }
   });
 
   document.addEventListener("click", (event) => {
     const target = event.target;
     if (!(target instanceof Element)) return;
+    let didRefresh = false;
     const activeSearch = document.querySelector("[data-submission-filter-input]")?.closest(".workspace-search");
-    if (activeSearch instanceof HTMLElement && activeSearch.contains(target)) return;
-    if (workspaceState.submissionFilterOpen) {
+    if (!(activeSearch instanceof HTMLElement && activeSearch.contains(target)) && workspaceState.submissionFilterOpen) {
       workspaceState.submissionFilterOpen = false;
       workspaceState.submissionFilterHighlight = -1;
+      didRefresh = true;
+    }
+    const entityLocationSearch = document.querySelector("[data-entity-filter-location]")?.closest(".workspace-search");
+    if (!(entityLocationSearch instanceof HTMLElement && entityLocationSearch.contains(target)) && workspaceState.entityLocationFilterOpen) {
+      workspaceState.entityLocationFilterOpen = false;
+      workspaceState.entityLocationFilterHighlight = -1;
+      didRefresh = true;
+    }
+    if (didRefresh) {
       renderWorkspace({ soft: true });
     }
   });
@@ -423,6 +455,9 @@ function bindWorkspace() {
     }
     if (target.matches("[data-entity-filter-location]")) {
       workspaceState.entityFilters.location = String(target.value || "");
+      const suggestions = entityLocationFilterSuggestions();
+      workspaceState.entityLocationFilterOpen = Boolean(String(target.value || "").trim() && suggestions.length);
+      workspaceState.entityLocationFilterHighlight = suggestions.length ? 0 : -1;
       renderWorkspace({ soft: true });
       return;
     }
@@ -450,6 +485,40 @@ function bindWorkspace() {
       event.preventDefault();
       await handleDirectUserLookup();
       return;
+    }
+    if (target.matches("[data-entity-filter-location]")) {
+      const suggestions = entityLocationFilterSuggestions();
+      if (event.key === "ArrowDown" && suggestions.length) {
+        event.preventDefault();
+        workspaceState.entityLocationFilterOpen = true;
+        workspaceState.entityLocationFilterHighlight = workspaceState.entityLocationFilterHighlight >= 0
+          ? (workspaceState.entityLocationFilterHighlight + 1) % suggestions.length
+          : 0;
+        renderWorkspace({ soft: true });
+        return;
+      }
+      if (event.key === "ArrowUp" && suggestions.length) {
+        event.preventDefault();
+        workspaceState.entityLocationFilterOpen = true;
+        workspaceState.entityLocationFilterHighlight = workspaceState.entityLocationFilterHighlight > 0
+          ? workspaceState.entityLocationFilterHighlight - 1
+          : suggestions.length - 1;
+        renderWorkspace({ soft: true });
+        return;
+      }
+      if (event.key === "Escape") {
+        workspaceState.entityLocationFilterOpen = false;
+        workspaceState.entityLocationFilterHighlight = -1;
+        renderWorkspace({ soft: true });
+        return;
+      }
+      if (event.key === "Enter" && suggestions.length) {
+        event.preventDefault();
+        const selected = suggestions[Math.max(0, workspaceState.entityLocationFilterHighlight)];
+        applyEntityLocationSuggestion(selected);
+        renderWorkspace({ soft: true });
+        return;
+      }
     }
     if (!target.matches("[data-submission-filter-input]")) return;
     const suggestions = submissionFilterSuggestions();
@@ -930,37 +999,35 @@ function renderUsersPane() {
       </section>
       <aside class="workspace-rail-stack">
         <section class="surface-panel workspace-rail-panel">
+          <label class="workspace-search">
+            <span class="sr-only">Username</span>
+            <input class="workspace-search__input" data-quick-user-input type="text" maxlength="80" placeholder="username" value="${escapeAttribute(workspaceState.userLookupQuery || "")}" autocomplete="off">
+            ${
+              workspaceState.userLookupQuery && !workspaceState.userLookupLoading
+                ? `<button class="workspace-search__clear" type="button" data-clear-user-lookup aria-label="Clear lookup">×</button>`
+                : ""
+            }
+            ${
+              workspaceState.userLookupLoading
+                ? `<span class="workspace-search__spinner" aria-hidden="true"><span class="loading-spinner"></span></span>`
+                : ""
+            }
+          </label>
           <label class="workspace-select">
             <span class="sr-only">Filter users by karma</span>
             <select data-user-filter-karma>
               ${renderKarmaSelectOptions(workspaceState.userFilters.karma)}
             </select>
           </label>
+          ${
+              workspaceState.userDirectStatus
+                ? `<div class="status-box">${escapeHtml(workspaceState.userDirectStatus)}</div>`
+                : ""
+          }
+          ${renderLookupCandidate()}
         </section>
         <section class="surface-panel workspace-rail-panel">
           ${renderUserStatsCard()}
-        </section>
-        <section class="surface-panel workspace-rail-panel">
-        <label class="workspace-search">
-          <span class="sr-only">Username</span>
-          <input class="workspace-search__input" data-quick-user-input type="text" maxlength="80" placeholder="username" value="${escapeAttribute(workspaceState.userLookupQuery || "")}" autocomplete="off">
-          ${
-            workspaceState.userLookupQuery && !workspaceState.userLookupLoading
-              ? `<button class="workspace-search__clear" type="button" data-clear-user-lookup aria-label="Clear lookup">×</button>`
-              : ""
-          }
-          ${
-            workspaceState.userLookupLoading
-              ? `<span class="workspace-search__spinner" aria-hidden="true"><span class="loading-spinner"></span></span>`
-              : ""
-          }
-        </label>
-        ${
-            workspaceState.userDirectStatus
-              ? `<div class="status-box">${escapeHtml(workspaceState.userDirectStatus)}</div>`
-              : ""
-        }
-        ${renderLookupCandidate()}
         </section>
       </aside>
     </div>
@@ -3577,6 +3644,7 @@ function findLocalUserCandidate(value) {
 
 function visibleWorkspaceUsers() {
   const karmaBucket = String(workspaceState.userFilters.karma || "").trim().toLowerCase();
+  const query = String(workspaceState.userLookupQuery || "").trim().toLowerCase();
   return (workspaceState.publicState?.users || []).filter((user) => {
     const visible =
       user.isAdmin ||
@@ -3588,7 +3656,17 @@ function visibleWorkspaceUsers() {
       (Array.isArray(user.socialLinks) && user.socialLinks.length) ||
       user.avatarUrl ||
       user.avatarBlob;
-    return visible && karmaBucketMatches(resolveWorkspaceUserKarma(user.pubkey), karmaBucket);
+    if (!visible || !karmaBucketMatches(resolveWorkspaceUserKarma(user.pubkey), karmaBucket)) return false;
+    if (!query) return true;
+    const haystacks = [
+      user.displayName,
+      user.username,
+      user.bio,
+      user.pubkey
+    ]
+      .map((value) => String(value || "").trim().toLowerCase())
+      .filter(Boolean);
+    return haystacks.some((value) => value.includes(query));
   });
 }
 
@@ -3686,12 +3764,13 @@ function renderEntityManagementRail() {
     </label>
     <label class="workspace-search">
       <span class="sr-only">Filter by state or country</span>
-      <input class="workspace-search__input" data-entity-filter-location type="text" maxlength="120" placeholder="State or country" value="${escapeAttribute(workspaceState.entityFilters.location || "")}" autocomplete="off">
+      <input class="workspace-search__input" data-entity-filter-location type="text" maxlength="120" placeholder="State or county" value="${escapeAttribute(workspaceState.entityFilters.location || "")}" autocomplete="off">
       ${
         workspaceState.entityFilters.location
           ? `<button class="workspace-search__clear" type="button" data-clear-entity-filter="location" aria-label="Clear location filter">×</button>`
           : ""
       }
+      ${renderEntityLocationFilterSuggestions()}
     </label>
     <label class="workspace-search">
       <span class="sr-only">Filter by submitting user</span>
@@ -3703,6 +3782,59 @@ function renderEntityManagementRail() {
       }
     </label>
   `;
+}
+
+function renderEntityLocationFilterSuggestions() {
+  const suggestions = entityLocationFilterSuggestions();
+  if (!suggestions.length || !workspaceState.entityLocationFilterOpen) return "";
+  return `
+    <div class="picker-results picker-results--dropdown workspace-search__results" data-open="yes">
+      ${suggestions
+        .map(
+          (value, index) => `
+            <button
+              class="picker-chip${workspaceState.entityLocationFilterHighlight === index ? " is-highlighted" : ""}"
+              type="button"
+              data-entity-location-suggestion="${escapeAttribute(value)}"
+              data-entity-location-index="${index}"
+              aria-selected="${workspaceState.entityLocationFilterHighlight === index ? "true" : "false"}"
+            >
+              <strong>${escapeHtml(value)}</strong>
+            </button>
+          `
+        )
+        .join("")}
+    </div>
+  `;
+}
+
+function entityLocationFilterSuggestions() {
+  const query = String(workspaceState.entityFilters.location || "").trim().toLowerCase();
+  if (!query) return [];
+  return buildEntityLocationFilterValues()
+    .filter((value) => value.toLowerCase().includes(query))
+    .slice(0, 8);
+}
+
+function buildEntityLocationFilterValues() {
+  return [...new Set(
+    (workspaceState.publicState?.entities || []).flatMap((entity) => {
+      const raw = String(entity?.location || "").trim();
+      if (!raw) return [];
+      const parts = raw.split(",").map((value) => value.trim()).filter(Boolean);
+      if (!parts.length) return [];
+      if (parts.length === 1) return parts;
+      return parts.filter((value, index) => index > 0 || /county/i.test(value));
+    })
+  )]
+    .filter(Boolean)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function applyEntityLocationSuggestion(value) {
+  workspaceState.entityFilters.location = String(value || "").trim();
+  workspaceState.entityLocationFilterOpen = false;
+  workspaceState.entityLocationFilterHighlight = -1;
 }
 
 function hydrateLookupCandidate(user) {

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1491,16 +1491,36 @@ function buildCommentTree(comments, publicState, viewerPubkey = "") {
   const roots = [];
   for (const node of nodes.values()) {
     const parentId = String(node.parent_id || "").trim();
-    const parent = parentId ? nodes.get(parentId) : null;
-    if (parent && parent.post_slug === node.post_slug) {
+    if (!parentId) {
+      roots.push(node);
+      continue;
+    }
+    const parent = nodes.get(parentId);
+    if (isCommentThreadAnchor(parent, node)) {
       if (!node.root_id) node.root_id = parent.root_id || parent.id;
       parent.replies.push(node);
-    } else {
-      roots.push(node);
+      continue;
+    }
+    const rootId = String(node.root_id || "").trim();
+    const threadRoot = rootId ? nodes.get(rootId) : null;
+    if (isCommentThreadAnchor(threadRoot, node)) {
+      node.root_id = threadRoot.id;
+      threadRoot.replies.push(node);
+      continue;
     }
   }
-  sortCommentNodes(roots, publicState, viewerPubkey);
+  sortRootCommentNodes(roots, publicState, viewerPubkey);
   return roots;
+}
+
+function isCommentThreadAnchor(anchor, node) {
+  return Boolean(
+    anchor &&
+    node &&
+    anchor.id !== node.id &&
+    String(anchor.post_slug || "").trim() &&
+    String(anchor.post_slug || "").trim() === String(node.post_slug || "").trim()
+  );
 }
 
 function focusRequestedComment(postSlug, attempt = 0) {
@@ -1568,7 +1588,7 @@ function closeUserProfileModal() {
   document.querySelector("[data-user-modal]")?.remove();
 }
 
-function sortCommentNodes(nodes, publicState, viewerPubkey = "") {
+function sortRootCommentNodes(nodes, publicState, viewerPubkey = "") {
   nodes.sort((left, right) => {
     const leftOwn = Boolean(viewerPubkey) && left?.author === viewerPubkey;
     const rightOwn = Boolean(viewerPubkey) && right?.author === viewerPubkey;
@@ -1583,7 +1603,19 @@ function sortCommentNodes(nodes, publicState, viewerPubkey = "") {
     return String(left?.id || "").localeCompare(String(right?.id || ""));
   });
   for (const node of nodes) {
-    if (Array.isArray(node.replies) && node.replies.length) sortCommentNodes(node.replies, publicState, viewerPubkey);
+    if (Array.isArray(node.replies) && node.replies.length) sortReplyCommentNodes(node.replies);
+  }
+}
+
+function sortReplyCommentNodes(nodes) {
+  nodes.sort((left, right) => {
+    const leftTime = Number(left?.created_at || 0);
+    const rightTime = Number(right?.created_at || 0);
+    if (leftTime !== rightTime) return leftTime - rightTime;
+    return String(left?.id || "").localeCompare(String(right?.id || ""));
+  });
+  for (const node of nodes) {
+    if (Array.isArray(node.replies) && node.replies.length) sortReplyCommentNodes(node.replies);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,8 @@
   --radius: 22px;
   --radius-small: 14px;
   --wrap: min(1160px, calc(100vw - 2rem));
+  --rail-stick-top: 6rem;
+  --rail-max-height: calc(100vh - 6.75rem);
 }
 
 * {
@@ -856,13 +858,14 @@ h3 {
   grid-column: 2;
   grid-row: 1;
   position: sticky;
-  top: 6rem;
+  top: var(--rail-stick-top);
   display: grid;
   gap: 1.2rem;
   align-self: start;
   align-content: start;
-  max-height: calc(100vh - 6.75rem);
+  max-height: var(--rail-max-height);
   overflow: auto;
+  overscroll-behavior: contain;
   padding-right: 0.1rem;
   scrollbar-gutter: stable;
 }
@@ -1520,9 +1523,15 @@ h3 {
 
 .article-aside {
   position: sticky;
-  top: 6rem;
+  top: var(--rail-stick-top);
   display: grid;
   gap: 1rem;
+  align-self: start;
+  max-height: var(--rail-max-height);
+  overflow: auto;
+  overscroll-behavior: contain;
+  padding-right: 0.1rem;
+  scrollbar-gutter: stable;
 }
 
 .page-layout--article {
@@ -2309,6 +2318,7 @@ h3 {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1.2rem;
+  align-items: start;
 }
 
 .workspace-grid--rail {
@@ -2323,13 +2333,24 @@ h3 {
   display: grid;
   gap: 1rem;
   position: sticky;
-  top: 6rem;
+  top: var(--rail-stick-top);
   align-self: start;
+  align-content: start;
+  max-height: var(--rail-max-height);
+  overflow: auto;
+  overscroll-behavior: contain;
+  padding-right: 0.1rem;
+  scrollbar-gutter: stable;
 }
 
 .workspace-rail-panel {
   display: grid;
   gap: 0.9rem;
+}
+
+.workspace-rail-panel .workspace-search,
+.workspace-rail-panel .workspace-select {
+  width: 100%;
 }
 
 .workspace-rail-copy {
@@ -3370,6 +3391,9 @@ body.is-static-editing [data-static-edit]:focus {
 
   .article-aside {
     position: static;
+    max-height: none;
+    overflow: visible;
+    padding-right: 0;
   }
 
   .workspace-grid {
@@ -3384,6 +3408,9 @@ body.is-static-editing [data-static-edit]:focus {
   .workspace-rail-stack {
     position: static;
     top: auto;
+    max-height: none;
+    overflow: visible;
+    padding-right: 0;
   }
 
   .workspace-filter-bar {


### PR DESCRIPTION
## Summary\n- keep reply threads anchored to their parent/root instead of surfacing orphan replies as top-level comments\n- merge user search and karma filtering into one full-width rail card\n- add state/county autocomplete to the entity filter rail\n- make sticky side rails internally scrollable and keep their tops aligned\n\n## Verification\n- node --check scripts/app.js\n- node --check scripts/admin.js\n- git diff --check\n\nCloses #69