### PR TITLE
(fix): normalize submit search field and checkbox controls

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -45,6 +45,8 @@ Component behavior that spans a whole UI family should live in `scripts/surfaces
 - Search, lookup, and filter controls should use one attached pattern.
 - Submit modal entity and location fields are part of the same pattern, not a separate form-specific widget family.
 - Suggestions open from the field itself and overlay what sits below.
+- Suggestions close on `Enter` and when the field loses focus.
+- Refocusing a field with a current value may reopen its attached suggestions.
 - Fields support:
   - `ArrowUp`
   - `ArrowDown`
@@ -53,6 +55,12 @@ Component behavior that spans a whole UI family should live in `scripts/surfaces
   - clear `x` inside the field
 - Clearing the field must clear the active filter state, not only the visible text.
 - Loading belongs in the field itself when the field is the active surface.
+
+### Checkbox controls
+
+- Checkboxes should render as intentional controls, not default browser boxes dropped into otherwise custom panels.
+- When a checkbox is presented as a full-width consent or settings row, the whole row should act as the control.
+- The checked and focus states must remain obvious without relying on browser-default styling.
 
 ## Workspace surfaces
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -9,6 +9,7 @@ Changes to live state, cached state, comments, filters, maps, workspace surfaces
 - a focused deterministic test for the data/state contract
 - a focused surface test when a new render family is extracted from a page controller
 - a browser regression when the failure mode is a runtime boot error, DOM lifecycle error, or broken attached-field interaction
+- a browser regression when a consent/settings control depends on custom checkbox or radio styling
 - syntax validation for touched modules
 - a clear statement of what user behavior was verified
 - a compatibility note when introducing non-baseline browser features
@@ -48,4 +49,6 @@ Use the checked-in browser regression whenever a fix touches:
 - admin/workspace boot
 - editor boot or editor lifecycle
 - attached autocomplete/dropdown geometry
+- attached autocomplete close behavior on `Enter` or blur
+- custom checkbox/radio toggle behavior inside a larger click target
 - other runtime paths that unit tests can miss because the failure only appears in a real browser

--- a/scripts/core/search-controls.js
+++ b/scripts/core/search-controls.js
@@ -16,6 +16,12 @@ export function cycleHighlightIndex(current, length, delta) {
   return (current + delta + length) % length;
 }
 
+export function closeSearchResults(host) {
+  if (!(host instanceof HTMLElement)) return;
+  host.innerHTML = "";
+  host.removeAttribute("data-open");
+}
+
 export function renderSearchField({
   wrapperClass = "workspace-search",
   wrapperAttributes = {},

--- a/scripts/submit.js
+++ b/scripts/submit.js
@@ -22,6 +22,7 @@ import {
   escapeHtml,
   lastCommaValue
 } from "./core/text-utils.js";
+import { closeSearchResults, cycleHighlightIndex } from "./core/search-controls.js";
 import { getStoredSession } from "./core/session.js";
 import {
   renderSubmitPageView,
@@ -39,7 +40,12 @@ const submitState = {
   loading: false,
   loadingMessage: "",
   formModal: null,
-  chatModal: null
+  chatModal: null,
+  searchUi: {
+    entityRefs: { highlight: -1, closedValue: "" },
+    location: { highlight: -1, closedValue: "" },
+    suggestedEntity: { highlight: -1, closedValue: "" }
+  }
 };
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -120,13 +126,42 @@ function bindSubmitPage() {
   shell.addEventListener("input", (event) => {
     const target = event.target;
     if (!(target instanceof Element)) return;
-    if (
-      target.matches(
-        "[data-submit-entity-input], [data-submit-location-input], [data-submit-suggested-entity-input]"
-      )
-    ) {
-      hydrateSubmissionEnhancements();
-    }
+    const fieldKey = resolveSubmitSearchFieldKey(target);
+    if (!fieldKey) return;
+    resetSubmitSearchField(fieldKey, readSubmitSearchValue(fieldKey));
+    hydrateSubmissionEnhancements();
+  });
+
+  shell.addEventListener("keydown", (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const fieldKey = resolveSubmitSearchFieldKey(target);
+    if (!fieldKey) return;
+    handleSubmitSearchKeydown(event, fieldKey);
+  });
+
+  shell.addEventListener("focusin", (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const fieldKey = resolveSubmitSearchFieldKey(target);
+    if (!fieldKey) return;
+    const value = readSubmitSearchValue(fieldKey);
+    if (!String(value || "").trim()) return;
+    const uiState = submitSearchUiState(fieldKey);
+    uiState.closedValue = "";
+    hydrateSubmissionEnhancements();
+  });
+
+  shell.addEventListener("focusout", (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const fieldKey = resolveSubmitSearchFieldKey(target);
+    if (!fieldKey) return;
+    const wrapper = target.closest(".workspace-search");
+    window.setTimeout(() => {
+      if (wrapper instanceof HTMLElement && wrapper.contains(document.activeElement)) return;
+      closeSubmitSearchField(fieldKey);
+    }, 0);
   });
 }
 
@@ -375,92 +410,115 @@ function hydrateSubmissionEnhancements() {
 }
 
 function renderEntityResults() {
-  const host = document.querySelector("[data-submit-entity-results]");
-  const input = document.querySelector("[data-submit-entity-input]");
+  const host = submitSearchHost("entityRefs");
+  const input = submitSearchInput("entityRefs");
   if (!(host instanceof HTMLElement) || !(input instanceof HTMLInputElement)) return;
   const query = lastCommaValue(input.value);
-  const matches = matchEntities(query).slice(0, 6);
-  if (!query) {
-    host.innerHTML = "";
-    host.removeAttribute("data-open");
+  if (!query || submitSearchUiState("entityRefs").closedValue === query) {
+    closeSearchResults(host);
     return;
   }
+  const matches = matchEntities(query).slice(0, 6);
   host.setAttribute("data-open", "yes");
   host.innerHTML = renderSubmitSuggestionMarkup(
     matches,
     `<div class="picker-hint">No existing entity matches. Use the suggested entity fields to add a new one for review.</div>`,
-    { kind: "entity", escapeAttribute, escapeHtml }
+    {
+      kind: "entity",
+      escapeAttribute,
+      escapeHtml,
+      highlightedIndex: submitSearchUiState("entityRefs").highlight
+    }
   );
 }
 
 function renderLocationResults() {
-  const host = document.querySelector("[data-submit-location-results]");
-  const input = document.querySelector("[data-submit-location-input]");
+  const host = submitSearchHost("location");
+  const input = submitSearchInput("location");
   if (!(host instanceof HTMLElement) || !(input instanceof HTMLInputElement)) return;
-  const query = input.value.trim().toLowerCase();
-  if (!query) {
-    host.innerHTML = "";
-    host.removeAttribute("data-open");
+  const rawValue = input.value.trim();
+  const query = rawValue.toLowerCase();
+  if (!query || submitSearchUiState("location").closedValue === rawValue) {
+    closeSearchResults(host);
     return;
   }
   const matches = uniqueLocations()
     .filter((location) => location.toLowerCase().includes(query))
     .slice(0, 6);
   if (!matches.length) {
-    host.innerHTML = "";
-    host.removeAttribute("data-open");
+    closeSearchResults(host);
     return;
   }
   host.setAttribute("data-open", "yes");
   host.innerHTML = renderSubmitSuggestionMarkup(
     matches,
     `<div class="picker-hint">No known location matches. Keep the typed value to propose a new one.</div>`,
-    { kind: "location", escapeAttribute, escapeHtml }
+    {
+      kind: "location",
+      escapeAttribute,
+      escapeHtml,
+      highlightedIndex: submitSearchUiState("location").highlight
+    }
   );
 }
 
 function renderSuggestedEntityResults() {
-  const host = document.querySelector("[data-submit-suggested-entity-results]");
-  const input = document.querySelector("[data-submit-suggested-entity-input]");
+  const host = submitSearchHost("suggestedEntity");
+  const input = submitSearchInput("suggestedEntity");
   if (!(host instanceof HTMLElement) || !(input instanceof HTMLInputElement)) return;
   const query = input.value.trim();
-  const matches = matchEntities(query).slice(0, 6);
-  if (!query) {
-    host.innerHTML = "";
-    host.removeAttribute("data-open");
+  if (!query || submitSearchUiState("suggestedEntity").closedValue === query) {
+    closeSearchResults(host);
     return;
   }
+  const matches = matchEntities(query).slice(0, 6);
   host.setAttribute("data-open", "yes");
   host.innerHTML = renderSubmitSuggestionMarkup(
     matches,
     `<div class="picker-hint">No existing entity matches. Keep the typed name to suggest a new one.</div>`,
-    { kind: "suggested-entity", escapeAttribute, escapeHtml }
+    {
+      kind: "suggested-entity",
+      escapeAttribute,
+      escapeHtml,
+      highlightedIndex: submitSearchUiState("suggestedEntity").highlight
+    }
   );
 }
 
 function applyEntityPick(button) {
-  const slug = button.getAttribute("data-submit-entity-pick") || "";
-  const entity = resolveEntityByNameOrSlug(slug);
-  const input = document.querySelector("[data-submit-entity-input]");
-  if (!entity || !(input instanceof HTMLInputElement)) return;
-  const existing = resolveEntityRefs(input.value);
-  input.value = dedupe([...existing, entity.slug]).map(resolveEntityDisplayValue).join(", ");
-  hydrateSubmissionEnhancements();
+  applyEntityPickValue(button.getAttribute("data-submit-entity-pick") || "");
 }
 
 function applyLocationPick(button) {
-  const value = button.getAttribute("data-submit-location-pick") || "";
-  const input = document.querySelector("[data-submit-location-input]");
-  if (!(input instanceof HTMLInputElement)) return;
-  input.value = value;
-  hydrateSubmissionEnhancements();
+  applyLocationValue(button.getAttribute("data-submit-location-pick") || "");
 }
 
 function applySuggestedEntityPick(button) {
-  const slug = button.getAttribute("data-submit-suggested-entity-pick") || "";
+  applySuggestedEntityValue(button.getAttribute("data-submit-suggested-entity-pick") || "");
+}
+
+function applyEntityPickValue(slug) {
   const entity = resolveEntityByNameOrSlug(slug);
-  const nameInput = document.querySelector("[data-submit-suggested-entity-input]");
-  const locationInput = document.querySelector("[data-submit-location-input]");
+  const input = submitSearchInput("entityRefs");
+  if (!entity || !(input instanceof HTMLInputElement)) return;
+  const existing = resolveEntityRefs(input.value);
+  input.value = `${dedupe([...existing, entity.slug]).map(resolveEntityDisplayValue).join(", ")}, `;
+  closeSubmitSearchField("entityRefs");
+  hydrateSubmissionEnhancements();
+}
+
+function applyLocationValue(value) {
+  const input = submitSearchInput("location");
+  if (!(input instanceof HTMLInputElement)) return;
+  input.value = value;
+  closeSubmitSearchField("location");
+  hydrateSubmissionEnhancements();
+}
+
+function applySuggestedEntityValue(slug) {
+  const entity = resolveEntityByNameOrSlug(slug);
+  const nameInput = submitSearchInput("suggestedEntity");
+  const locationInput = submitSearchInput("location");
   const typeInput = document.querySelector('[name="suggestedEntityType"]');
   const notesInput = document.querySelector('[name="suggestedEntityNotes"]');
   if (!(nameInput instanceof HTMLInputElement) || !entity) return;
@@ -468,6 +526,8 @@ function applySuggestedEntityPick(button) {
   if (locationInput instanceof HTMLInputElement) locationInput.value = entity.location || "";
   if (typeInput instanceof HTMLInputElement) typeInput.value = entity.type || "";
   if (notesInput instanceof HTMLInputElement) notesInput.value = entity.notes || "";
+  closeSubmitSearchField("suggestedEntity");
+  closeSubmitSearchField("location");
   hydrateSubmissionEnhancements();
 }
 
@@ -475,7 +535,134 @@ function clearSubmissionField(fieldName) {
   const input = document.querySelector(`[name="${fieldName}"]`);
   if (!(input instanceof HTMLInputElement)) return;
   input.value = "";
+  const fieldKey = clearableSubmitFieldKey(fieldName);
+  if (fieldKey) resetSubmitSearchField(fieldKey, "");
   hydrateSubmissionEnhancements();
+}
+
+function handleSubmitSearchKeydown(event, fieldKey) {
+  const suggestions = submitSuggestions(fieldKey);
+  if (!suggestions.length && event.key !== "Escape" && event.key !== "Enter") return;
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+    submitSearchUiState(fieldKey).highlight = cycleHighlightIndex(submitSearchUiState(fieldKey).highlight, suggestions.length, 1);
+    hydrateSubmissionEnhancements();
+    return;
+  }
+  if (event.key === "ArrowUp") {
+    event.preventDefault();
+    submitSearchUiState(fieldKey).highlight = cycleHighlightIndex(submitSearchUiState(fieldKey).highlight, suggestions.length, -1);
+    hydrateSubmissionEnhancements();
+    return;
+  }
+  if (event.key === "Enter") {
+    const host = submitSearchHost(fieldKey);
+    const isOpen = host instanceof HTMLElement && host.getAttribute("data-open") === "yes";
+    if (!isOpen) return;
+    event.preventDefault();
+    const highlight = submitSearchUiState(fieldKey).highlight;
+    if (highlight >= 0 && suggestions[highlight] !== undefined) {
+      commitSubmitSuggestion(fieldKey, suggestions[highlight]);
+      submitSearchInput(fieldKey)?.blur();
+      return;
+    }
+    closeSubmitSearchField(fieldKey);
+    submitSearchInput(fieldKey)?.blur();
+    return;
+  }
+  if (event.key === "Escape") {
+    closeSubmitSearchField(fieldKey);
+  }
+}
+
+function commitSubmitSuggestion(fieldKey, suggestion) {
+  if (fieldKey === "entityRefs") {
+    applyEntityPickValue(suggestion?.slug || "");
+    return;
+  }
+  if (fieldKey === "location") {
+    applyLocationValue(String(suggestion || ""));
+    return;
+  }
+  if (fieldKey === "suggestedEntity") {
+    applySuggestedEntityValue(suggestion?.slug || "");
+  }
+}
+
+function submitSearchUiState(fieldKey) {
+  return submitState.searchUi[fieldKey];
+}
+
+function resetSubmitSearchField(fieldKey, currentValue = "") {
+  const state = submitSearchUiState(fieldKey);
+  if (!state) return;
+  state.highlight = -1;
+  if (state.closedValue && state.closedValue !== String(currentValue || "").trim()) {
+    state.closedValue = "";
+  }
+}
+
+function closeSubmitSearchField(fieldKey) {
+  const state = submitSearchUiState(fieldKey);
+  const host = submitSearchHost(fieldKey);
+  const value = readSubmitSearchValue(fieldKey);
+  if (state) {
+    state.highlight = -1;
+    state.closedValue = value;
+  }
+  closeSearchResults(host);
+}
+
+function resolveSubmitSearchFieldKey(target) {
+  if (!(target instanceof Element)) return "";
+  if (target.matches("[data-submit-entity-input]")) return "entityRefs";
+  if (target.matches("[data-submit-location-input]")) return "location";
+  if (target.matches("[data-submit-suggested-entity-input]")) return "suggestedEntity";
+  return "";
+}
+
+function clearableSubmitFieldKey(fieldName) {
+  return {
+    entityRefs: "entityRefs",
+    suggestedEntityName: "suggestedEntity",
+    suggestedEntityLocation: "location"
+  }[fieldName] || "";
+}
+
+function submitSearchInput(fieldKey) {
+  const selector = {
+    entityRefs: "[data-submit-entity-input]",
+    location: "[data-submit-location-input]",
+    suggestedEntity: "[data-submit-suggested-entity-input]"
+  }[fieldKey];
+  return selector ? document.querySelector(selector) : null;
+}
+
+function submitSearchHost(fieldKey) {
+  const selector = {
+    entityRefs: "[data-submit-entity-results]",
+    location: "[data-submit-location-results]",
+    suggestedEntity: "[data-submit-suggested-entity-results]"
+  }[fieldKey];
+  return selector ? document.querySelector(selector) : null;
+}
+
+function readSubmitSearchValue(fieldKey) {
+  const input = submitSearchInput(fieldKey);
+  if (!(input instanceof HTMLInputElement)) return "";
+  if (fieldKey === "entityRefs") return lastCommaValue(input.value).trim();
+  return input.value.trim();
+}
+
+function submitSuggestions(fieldKey) {
+  if (fieldKey === "entityRefs") return matchEntities(readSubmitSearchValue(fieldKey)).slice(0, 6);
+  if (fieldKey === "location") {
+    const query = readSubmitSearchValue(fieldKey).toLowerCase();
+    if (!query) return [];
+    return uniqueLocations().filter((location) => location.toLowerCase().includes(query)).slice(0, 6);
+  }
+  if (fieldKey === "suggestedEntity") return matchEntities(readSubmitSearchValue(fieldKey)).slice(0, 6);
+  return [];
 }
 
 function buildSuggestedEntity(formData, existingEntity) {

--- a/scripts/surfaces/submit-shell.js
+++ b/scripts/surfaces/submit-shell.js
@@ -2,6 +2,28 @@ import { renderSearchField } from "../core/search-controls.js";
 
 export function renderSubmitPageView({ submitState, deps = {} } = {}) {
   const renderLoadingState = deps.renderLoadingState || ((value) => String(value || ""));
+  if (submitState.loading && submitState.session) {
+    return {
+      lede: submitState.loadingMessage || "Looking up your submissions...",
+      shellMarkup: `
+        <section class="surface-panel">
+          <div class="workspace-list__row">
+            <div>
+              <div class="eyebrow">Submit</div>
+              <h2>Your submissions</h2>
+            </div>
+            <button class="button" type="button" data-open-submission-modal="new">Add submission</button>
+          </div>
+          <div class="roster-list">
+            ${renderLoadingState(submitState.loadingMessage || "Looking up your submissions...")}
+          </div>
+        </section>
+        ${renderSubmissionModal(submitState, deps)}
+        ${renderSubmissionChatModal(submitState, deps)}
+      `
+    };
+  }
+
   if (submitState.loading) {
     return {
       lede: submitState.loadingMessage || "Looking up your submissions...",
@@ -242,7 +264,8 @@ export function renderSubmissionModal(submitState, deps = {}) {
             </label>
           </div>
           <label class="checkbox checkbox--panel">
-            <input name="consent" type="checkbox" value="yes" ${payload.consent_to_follow_up ? "checked" : ""}>
+            <input class="checkbox__input" name="consent" type="checkbox" value="yes" ${payload.consent_to_follow_up ? "checked" : ""}>
+            <span class="checkbox__indicator" aria-hidden="true"></span>
             <span class="checkbox__copy">
               <strong>Allow follow-up</strong>
               <small>We may contact you if a quick clarification would help.</small>
@@ -313,18 +336,20 @@ export function renderSubmitSuggestionMarkup(items, emptyMarkup, deps = {}) {
   const escapeAttribute = deps.escapeAttribute || ((value) => String(value || ""));
   const escapeHtml = deps.escapeHtml || ((value) => String(value || ""));
   const kind = deps.kind || "entity";
+  const highlightedIndex = Number.isInteger(deps.highlightedIndex) ? deps.highlightedIndex : -1;
   if (!items.length) return emptyMarkup;
   return items
-    .map((item) => {
+    .map((item, index) => {
+      const highlightedClass = highlightedIndex === index ? " is-highlighted" : "";
       if (kind === "location") {
         return `
-          <button class="workspace-search__option" type="button" data-submit-location-pick="${escapeAttribute(item)}">
+          <button class="workspace-search__option${highlightedClass}" type="button" data-submit-location-pick="${escapeAttribute(item)}" aria-selected="${highlightedIndex === index ? "true" : "false"}">
             <strong>${escapeHtml(item)}</strong>
           </button>
         `;
       }
       return `
-        <button class="workspace-search__option" type="button" data-submit-${kind}-pick="${escapeAttribute(item.slug)}">
+        <button class="workspace-search__option${highlightedClass}" type="button" data-submit-${kind}-pick="${escapeAttribute(item.slug)}" aria-selected="${highlightedIndex === index ? "true" : "false"}">
           <strong>${escapeHtml(item.name)}</strong>
           <span class="workspace-search__option-meta">${escapeHtml(item.location)}</span>
         </button>

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,16 @@
   --shadow: 0 24px 60px rgba(18, 18, 18, 0.12);
   --radius: 22px;
   --radius-small: 14px;
+  --control-height: 3.35rem;
+  --control-radius: 18px;
+  --control-radius-soft: 16px;
+  --control-padding: 0.95rem 1rem;
+  --control-border: 1px solid var(--line);
+  --control-bg: rgba(255, 255, 255, 0.82);
+  --control-bg-soft: rgba(255, 255, 255, 0.72);
+  --control-panel-bg: rgba(18, 18, 18, 0.05);
+  --dropdown-bg: rgba(250, 247, 241, 0.96);
+  --dropdown-border: 1px solid rgba(18, 18, 18, 0.08);
   --wrap: min(1160px, calc(100vw - 2rem));
   --rail-stick-top: 6rem;
   --rail-max-height: calc(100vh - 6.75rem);
@@ -888,7 +898,8 @@ h3 {
   padding: 1.45rem;
 }
 
-.archive-filters {
+.archive-filters,
+.workspace-stats-card {
   display: grid;
   gap: 0.8rem;
 }
@@ -932,16 +943,28 @@ h3 {
   z-index: 42;
 }
 
+:where(
+  .archive-filters__field input,
+  .workspace-search__input,
+  .archive-status-menu__toggle,
+  .workspace-select select,
+  .tip-form input:not([type="checkbox"]):not([type="file"]),
+  .tip-form select,
+  .tip-form textarea,
+  .comment-note-field textarea
+) {
+  border: var(--control-border);
+  color: var(--ink);
+  font: inherit;
+}
+
 .archive-filters__field input,
 .workspace-search__input {
   width: 100%;
-  min-height: 3.35rem;
+  min-height: var(--control-height);
   padding: 0.95rem 3.25rem 0.95rem 1rem;
-  border-radius: 18px;
-  border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.82);
-  color: var(--ink);
-  font: inherit;
+  border-radius: var(--control-radius);
+  background: var(--control-bg);
 }
 
 .archive-filters__field input::placeholder,
@@ -949,21 +972,24 @@ h3 {
   color: rgba(74, 71, 66, 0.72);
 }
 
-.archive-filters__results {
-  margin-top: 0;
+:where(.archive-filters__results, .workspace-search__results, .picker-results--dropdown, .archive-status-menu__panel) {
   position: absolute;
   top: calc(100% + 0.35rem);
   left: 0;
   right: 0;
+}
+
+.archive-filters__results,
+.workspace-search__results {
+  margin-top: 0;
+}
+
+.archive-filters__results,
+.picker-results--dropdown {
   z-index: 30;
 }
 
 .workspace-search__results {
-  margin-top: 0;
-  position: absolute;
-  top: calc(100% + 0.35rem);
-  left: 0;
-  right: 0;
   z-index: 36;
 }
 
@@ -1046,14 +1072,14 @@ h3 {
   justify-content: space-between;
   gap: 0.8rem;
   width: 100%;
-  min-height: 3.35rem;
-  padding: 0.95rem 1rem;
-  border-radius: 18px;
-  border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.82);
-  color: var(--ink);
-  font: inherit;
   cursor: pointer;
+}
+
+:where(.archive-status-menu__toggle, .workspace-select select) {
+  min-height: var(--control-height);
+  padding: var(--control-padding);
+  border-radius: var(--control-radius);
+  background: var(--control-bg);
 }
 
 .archive-status-menu__toggle::after {
@@ -1077,18 +1103,17 @@ h3 {
 }
 
 .archive-status-menu__panel {
-  position: absolute;
-  top: calc(100% + 0.35rem);
-  left: 0;
-  right: 0;
   z-index: 34;
   display: grid;
   gap: 0.35rem;
-  padding: 0.5rem;
-  border-radius: 18px;
-  border: 1px solid rgba(18, 18, 18, 0.08);
-  background: rgba(250, 247, 241, 0.98);
   box-shadow: 0 18px 35px rgba(18, 18, 18, 0.12);
+}
+
+:where(.archive-status-menu__panel, .picker-results--dropdown) {
+  padding: 0.5rem;
+  border-radius: var(--control-radius);
+  border: var(--dropdown-border);
+  background: var(--dropdown-bg);
 }
 
 .archive-status-menu__panel[hidden] {
@@ -1627,8 +1652,8 @@ h3 {
   display: grid;
   gap: 0.2rem;
   padding: 0.9rem 1rem;
-  border-radius: 14px;
-  background: rgba(18, 18, 18, 0.05);
+  border-radius: var(--radius-small);
+  background: var(--control-panel-bg);
 }
 
 .record-item strong {
@@ -1716,11 +1741,10 @@ h3 {
 }
 
 .review-card {
-  display: grid;
   gap: 0.65rem;
   padding: 1.15rem 1.2rem;
-  border-radius: 18px;
-  background: rgba(18, 18, 18, 0.05);
+  border-radius: var(--control-radius);
+  background: var(--control-panel-bg);
   border: 1px solid rgba(18, 18, 18, 0.06);
 }
 
@@ -2096,17 +2120,31 @@ h3 {
 .tip-form select,
 .tip-form textarea {
   width: 100%;
-  padding: 0.95rem 1rem;
-  border-radius: 16px;
-  border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.72);
-  font: inherit;
-  color: var(--ink);
+  padding: var(--control-padding);
+  border-radius: var(--control-radius-soft);
+  background: var(--control-bg-soft);
 }
 
 .tip-form textarea {
   min-height: 13rem;
   resize: vertical;
+}
+
+.tip-form input[type="file"]::file-selector-button {
+  margin-right: 0.8rem;
+  padding: 0.65rem 0.95rem;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(18, 18, 18, 0.08);
+  color: var(--ink);
+  font: inherit;
+  cursor: pointer;
+}
+
+.tip-form input[type="file"]::file-selector-button:hover,
+.tip-form input[type="file"]::file-selector-button:focus-visible {
+  background: rgba(156, 29, 24, 0.12);
+  outline: none;
 }
 
 .tip-form__split {
@@ -2134,8 +2172,8 @@ h3 {
 }
 
 .submit-search-field .workspace-search__results {
-  top: calc(100% + 0.35rem);
   padding: 0.35rem;
+  overflow: hidden;
 }
 
 .submit-search-field .workspace-search__input {
@@ -2146,33 +2184,101 @@ h3 {
   border-radius: 14px;
 }
 
+.submit-form-note,
+.status-box {
+  padding: var(--control-padding);
+  border-radius: var(--control-radius-soft);
+}
+
 .submit-form-note {
-  padding: 0.95rem 1rem;
-  border-radius: 16px;
-  background: rgba(18, 18, 18, 0.05);
+  background: var(--control-panel-bg);
   color: var(--ink-soft);
 }
 
-.checkbox {
-  display: flex;
-  align-items: start;
-  gap: 0.75rem;
+:where(.record-item, .review-card, .roster-item) {
+  display: grid;
 }
 
-.checkbox input {
-  width: auto;
-  margin-top: 0.25rem;
+.checkbox {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+  gap: 0.85rem;
+  cursor: pointer;
+}
+
+.checkbox__input {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
 }
 
 .checkbox--panel {
-  padding: 0.95rem 1rem;
-  border-radius: 16px;
-  background: rgba(18, 18, 18, 0.05);
+  padding: var(--control-padding);
+  border-radius: var(--control-radius-soft);
+  border: var(--control-border);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.62), rgba(255, 255, 255, 0.36)),
+    var(--control-panel-bg);
+  transition: border-color 180ms ease, box-shadow 180ms ease, background 180ms ease;
+}
+
+.checkbox--panel:hover,
+.checkbox--panel:focus-within {
+  border-color: rgba(156, 29, 24, 0.22);
+  box-shadow: 0 12px 28px rgba(18, 18, 18, 0.08);
+}
+
+.checkbox__indicator {
+  display: inline-grid;
+  place-items: center;
+  width: 1.3rem;
+  height: 1.3rem;
+  margin-top: 0.15rem;
+  border-radius: 0.4rem;
+  border: 1.5px solid rgba(74, 71, 66, 0.42);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
+  transition: border-color 180ms ease, background 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+.checkbox__indicator::after {
+  content: "";
+  width: 0.52rem;
+  height: 0.28rem;
+  border-left: 2px solid #fff;
+  border-bottom: 2px solid #fff;
+  transform: rotate(-45deg) scale(0.4);
+  opacity: 0;
+  transition: transform 180ms ease, opacity 180ms ease;
+}
+
+.checkbox__input:checked + .checkbox__indicator {
+  border-color: rgba(156, 29, 24, 0.9);
+  background: linear-gradient(180deg, rgba(156, 29, 24, 0.95), rgba(111, 13, 9, 0.95));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    0 10px 20px rgba(156, 29, 24, 0.2);
+}
+
+.checkbox__input:checked + .checkbox__indicator::after {
+  transform: rotate(-45deg) scale(1);
+  opacity: 1;
+}
+
+.checkbox__input:focus-visible + .checkbox__indicator {
+  outline: 3px solid rgba(156, 29, 24, 0.18);
+  outline-offset: 2px;
 }
 
 .checkbox__copy {
   display: grid;
-  gap: 0.2rem;
+  gap: 0.28rem;
 }
 
 .checkbox__copy strong {
@@ -2187,8 +2293,6 @@ h3 {
 
 .status-box {
   min-height: 3rem;
-  padding: 1rem 1.1rem;
-  border-radius: 16px;
   background: rgba(18, 18, 18, 0.06);
   color: var(--ink);
 }
@@ -2236,11 +2340,10 @@ h3 {
 }
 
 .roster-item {
-  display: grid;
   gap: 0.3rem;
   padding: 1rem;
-  border-radius: 16px;
-  background: rgba(18, 18, 18, 0.05);
+  border-radius: var(--control-radius-soft);
+  background: var(--control-panel-bg);
 }
 
 .roster-item--focus {
@@ -2453,11 +2556,6 @@ h3 {
   gap: 0.35rem;
 }
 
-.workspace-stats-card {
-  display: grid;
-  gap: 0.8rem;
-}
-
 .workspace-stats-card__grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2504,16 +2602,6 @@ h3 {
 
 .workspace-filter-bar--stacked {
   grid-template-columns: minmax(0, 1fr);
-}
-
-.workspace-select select {
-  min-height: 3.35rem;
-  padding: 0.95rem 1rem;
-  border-radius: 18px;
-  border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.82);
-  color: var(--ink);
-  font: inherit;
 }
 
 .workspace-list__row {
@@ -2590,9 +2678,7 @@ h3 {
   min-height: 5.5rem;
   padding: 0.8rem 0.9rem;
   border-radius: 14px;
-  border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.72);
-  font: inherit;
+  background: var(--control-bg-soft);
 }
 
 .picker-results {
@@ -2602,18 +2688,9 @@ h3 {
 }
 
 .picker-results--dropdown {
-  position: absolute;
-  top: calc(100% + 0.35rem);
-  left: 0;
-  right: 0;
-  z-index: 30;
-  padding: 0.5rem;
   max-height: 15rem;
   overflow: auto;
   overscroll-behavior: contain;
-  border-radius: 18px;
-  border: 1px solid rgba(18, 18, 18, 0.08);
-  background: rgba(250, 247, 241, 0.96);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
 }
 
@@ -2621,22 +2698,27 @@ h3 {
   display: none;
 }
 
-.picker-chip {
+.picker-chip,
+.picker-create {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.9rem;
   width: 100%;
-  padding: 0.7rem 0.9rem;
-  border-radius: 14px;
-  border: 1px solid rgba(18, 18, 18, 0.08);
-  background: rgba(255, 255, 255, 0.78);
   color: var(--ink);
   text-align: left;
   cursor: pointer;
 }
 
-.picker-chip strong {
+.picker-chip {
+  padding: 0.7rem 0.9rem;
+  border-radius: 14px;
+  border: 1px solid rgba(18, 18, 18, 0.08);
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.picker-chip strong,
+.picker-create strong {
   font-size: 0.95rem;
 }
 
@@ -2674,22 +2756,10 @@ h3 {
 }
 
 .picker-create {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.9rem;
-  width: 100%;
   padding: 0.8rem 0.95rem;
   border-radius: 14px;
   border: 1px dashed rgba(156, 29, 24, 0.3);
   background: rgba(156, 29, 24, 0.06);
-  color: var(--ink);
-  text-align: left;
-  cursor: pointer;
-}
-
-.picker-create strong {
-  font-size: 0.95rem;
 }
 
 .picker-create span {

--- a/tests/admin-editor-submit.browser.test.mjs
+++ b/tests/admin-editor-submit.browser.test.mjs
@@ -119,21 +119,20 @@ test("admin workspace, submit autocomplete, and editor boot survive cached admin
     await page.waitForSelector("[data-submission-form]", { timeout: 15000 });
 
     const resultsClosedBeforeTyping = await page.evaluate(() => {
-      const host = document.querySelector("[data-submit-location-results]");
+      const host = document.querySelector("[data-submit-suggested-entity-results]");
       return host instanceof HTMLElement ? host.getAttribute("data-open") !== "yes" : false;
     });
 
-    await page.fill("[data-submit-location-input]", "ph");
+    await page.fill("[data-submit-suggested-entity-input]", "Test");
     await page.waitForFunction(
-      () => document.querySelector("[data-submit-location-results]")?.getAttribute("data-open") === "yes",
+      () => document.querySelector("[data-submit-suggested-entity-results]")?.getAttribute("data-open") === "yes",
       { timeout: 5000 }
     );
 
-    const locationFieldMetrics = await page.evaluate(() => {
-      const input = document.querySelector("[data-submit-location-input]");
-      const host = document.querySelector("[data-submit-location-results]");
+    const attachedFieldMetrics = await page.evaluate(() => {
+      const input = document.querySelector("[data-submit-suggested-entity-input]");
+      const host = document.querySelector("[data-submit-suggested-entity-results]");
       const wrapper = input?.closest(".workspace-search");
-      const option = host?.querySelector("button");
       if (!(input instanceof HTMLElement) || !(host instanceof HTMLElement) || !(wrapper instanceof HTMLElement)) return null;
       const inputRect = input.getBoundingClientRect();
       const hostRect = host.getBoundingClientRect();
@@ -143,7 +142,38 @@ test("admin workspace, submit autocomplete, and editor boot survive cached admin
         hostTop: hostRect.top,
         hostWidth: hostRect.width,
         wrapperWidth: wrapperRect.width,
-        optionClass: option?.className || ""
+        openHintVisible: host.textContent.includes("No existing entity matches")
+      };
+    });
+
+    await page.press("[data-submit-suggested-entity-input]", "Enter");
+    await page.waitForFunction(
+      () => document.querySelector("[data-submit-suggested-entity-results]")?.getAttribute("data-open") !== "yes",
+      { timeout: 5000 }
+    );
+
+    await page.focus("[data-submit-suggested-entity-input]");
+    await page.waitForFunction(
+      () => document.querySelector("[data-submit-suggested-entity-results]")?.getAttribute("data-open") === "yes",
+      { timeout: 5000 }
+    );
+    await page.focus("[name=\"suggestedEntityNotes\"]");
+    await page.waitForFunction(
+      () => document.querySelector("[data-submit-suggested-entity-results]")?.getAttribute("data-open") !== "yes",
+      { timeout: 5000 }
+    );
+
+    const checkboxState = await page.evaluate(() => {
+      const label = document.querySelector(".checkbox--panel");
+      const input = document.querySelector(".checkbox__input");
+      const indicator = document.querySelector(".checkbox__indicator");
+      if (!(label instanceof HTMLElement) || !(input instanceof HTMLInputElement) || !(indicator instanceof HTMLElement)) {
+        return null;
+      }
+      label.click();
+      return {
+        checkedAfterClick: input.checked,
+        indicatorPresent: indicator instanceof HTMLElement
       };
     });
 
@@ -154,11 +184,13 @@ test("admin workspace, submit autocomplete, and editor boot survive cached admin
 
     assert.deepEqual(pageErrors, [], `page errors: ${pageErrors.join(" | ")}`);
     assert.deepEqual(consoleErrors, [], `console errors: ${consoleErrors.join(" | ")}`);
-    assert.equal(resultsClosedBeforeTyping, true, "location suggestions should stay closed until the field has input");
-    assert.ok(locationFieldMetrics, "location field metrics should be available");
-    assert.ok(locationFieldMetrics.hostTop >= locationFieldMetrics.inputBottom - 2, "location suggestions should attach below the input");
-    assert.ok(locationFieldMetrics.hostWidth <= locationFieldMetrics.wrapperWidth + 2, "location suggestions should stay within the field width");
-    assert.match(locationFieldMetrics.optionClass, /workspace-search__option/, "location suggestions should use normalized autocomplete rows");
+    assert.equal(resultsClosedBeforeTyping, true, "attached suggestions should stay closed until the field has input");
+    assert.ok(attachedFieldMetrics, "attached field metrics should be available");
+    assert.ok(attachedFieldMetrics.hostTop >= attachedFieldMetrics.inputBottom - 2, "attached suggestions should render below the input");
+    assert.ok(attachedFieldMetrics.hostWidth <= attachedFieldMetrics.wrapperWidth + 2, "attached suggestions should stay within the field width");
+    assert.equal(attachedFieldMetrics.openHintVisible, true, "attached dropdown should render its empty-state hint in place");
+    assert.ok(checkboxState?.indicatorPresent, "consent checkbox should render a styled indicator");
+    assert.equal(checkboxState?.checkedAfterClick, true, "consent checkbox should toggle from the panel control");
   } finally {
     await browser.close();
     await new Promise((resolve) => server.close(resolve));

--- a/tests/submit-shell.test.mjs
+++ b/tests/submit-shell.test.mjs
@@ -17,10 +17,11 @@ const deps = {
 
 test("submit shell renders cache-first loading and sessionless states distinctly", () => {
   const loadingView = renderSubmitPageView({
-    submitState: { loading: true, loadingMessage: "Looking up your submissions..." },
+    submitState: { loading: true, loadingMessage: "Looking up your submissions...", session: { username: "aux" } },
     deps
   });
   assert.match(loadingView.shellMarkup, /data-loading/);
+  assert.match(loadingView.shellMarkup, /data-open-submission-modal="new"/);
 
   const gateView = renderSubmitPageView({
     submitState: { loading: false, session: null, submissions: [] },
@@ -54,6 +55,7 @@ test("submit shell renders attached search fields and consent copy inside the mo
   assert.match(view.shellMarkup, /data-submit-suggested-entity-results/);
   assert.match(view.shellMarkup, /data-submit-location-results/);
   assert.match(view.shellMarkup, /Allow follow-up/);
+  assert.match(view.shellMarkup, /checkbox__indicator/);
 });
 
 test("submit suggestion markup keeps attached dropdown semantics for each field kind", () => {
@@ -77,8 +79,9 @@ test("submit suggestion markup keeps attached dropdown semantics for each field 
   const locationMarkup = renderSubmitSuggestionMarkup(
     ["Phoenix, Arizona"],
     "",
-    { kind: "location", escapeAttribute: deps.escapeAttribute, escapeHtml: deps.escapeHtml }
+    { kind: "location", escapeAttribute: deps.escapeAttribute, escapeHtml: deps.escapeHtml, highlightedIndex: 0 }
   );
   assert.match(locationMarkup, /data-submit-location-pick="Phoenix, Arizona"/);
   assert.match(locationMarkup, /workspace-search__option/);
+  assert.match(locationMarkup, /is-highlighted/);
 });


### PR DESCRIPTION
## Summary
- close submit attached autocomplete fields on `Enter` and blur, and reopen them correctly on refocus
- normalize the submit consent checkbox into a real panel control instead of a stray browser-default box
- add browser regression coverage for admin boot, editor boot, attached search behavior, and checkbox toggling
- make an initial control-token consolidation pass in `styles.css`

Closes #81
Closes #82
Refs #83

## Testing
- `node --check scripts/core/search-controls.js`
- `node --check scripts/submit.js`
- `node --check scripts/surfaces/submit-shell.js`
- `node --test tests/submit-shell.test.mjs tests/search-controls.test.mjs tests/admin-editor-submit.browser.test.mjs`
