### PR TITLE
(docs): trim superfluous submit control regression requirements

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -9,10 +9,11 @@ Changes to live state, cached state, comments, filters, maps, workspace surfaces
 - a focused deterministic test for the data/state contract
 - a focused surface test when a new render family is extracted from a page controller
 - a browser regression when the failure mode is a runtime boot error, DOM lifecycle error, or broken attached-field interaction
-- a browser regression when a consent/settings control depends on custom checkbox or radio styling
 - syntax validation for touched modules
 - a clear statement of what user behavior was verified
 - a compatibility note when introducing non-baseline browser features
+
+Pure presentation refinements should be checked in manual design runs unless they change runtime behavior or a documented interaction contract.
 
 ## Required live-state cases
 
@@ -50,5 +51,4 @@ Use the checked-in browser regression whenever a fix touches:
 - editor boot or editor lifecycle
 - attached autocomplete/dropdown geometry
 - attached autocomplete close behavior on `Enter` or blur
-- custom checkbox/radio toggle behavior inside a larger click target
 - other runtime paths that unit tests can miss because the failure only appears in a real browser

--- a/tests/admin-editor-submit.browser.test.mjs
+++ b/tests/admin-editor-submit.browser.test.mjs
@@ -163,20 +163,6 @@ test("admin workspace, submit autocomplete, and editor boot survive cached admin
       { timeout: 5000 }
     );
 
-    const checkboxState = await page.evaluate(() => {
-      const label = document.querySelector(".checkbox--panel");
-      const input = document.querySelector(".checkbox__input");
-      const indicator = document.querySelector(".checkbox__indicator");
-      if (!(label instanceof HTMLElement) || !(input instanceof HTMLInputElement) || !(indicator instanceof HTMLElement)) {
-        return null;
-      }
-      label.click();
-      return {
-        checkedAfterClick: input.checked,
-        indicatorPresent: indicator instanceof HTMLElement
-      };
-    });
-
     await seedSession(page);
     await page.goto(`http://127.0.0.1:${port}/editor.html`, { waitUntil: "domcontentloaded" });
     await page.waitForSelector("[data-editor-form]", { timeout: 15000 });
@@ -189,8 +175,6 @@ test("admin workspace, submit autocomplete, and editor boot survive cached admin
     assert.ok(attachedFieldMetrics.hostTop >= attachedFieldMetrics.inputBottom - 2, "attached suggestions should render below the input");
     assert.ok(attachedFieldMetrics.hostWidth <= attachedFieldMetrics.wrapperWidth + 2, "attached suggestions should stay within the field width");
     assert.equal(attachedFieldMetrics.openHintVisible, true, "attached dropdown should render its empty-state hint in place");
-    assert.ok(checkboxState?.indicatorPresent, "consent checkbox should render a styled indicator");
-    assert.equal(checkboxState?.checkedAfterClick, true, "consent checkbox should toggle from the panel control");
   } finally {
     await browser.close();
     await new Promise((resolve) => server.close(resolve));

--- a/tests/submit-shell.test.mjs
+++ b/tests/submit-shell.test.mjs
@@ -55,7 +55,6 @@ test("submit shell renders attached search fields and consent copy inside the mo
   assert.match(view.shellMarkup, /data-submit-suggested-entity-results/);
   assert.match(view.shellMarkup, /data-submit-location-results/);
   assert.match(view.shellMarkup, /Allow follow-up/);
-  assert.match(view.shellMarkup, /checkbox__indicator/);
 });
 
 test("submit suggestion markup keeps attached dropdown semantics for each field kind", () => {


### PR DESCRIPTION
## Summary
- remove checkbox-specific assertions from the submit browser regression and shell test
- keep checkbox presentation as a component/style expectation rather than a dedicated automated-regression requirement
- clarify that pure presentation refinements are checked in manual design runs unless they change runtime behavior or an interaction contract

Closes #85

## Testing
- `node --test tests/submit-shell.test.mjs tests/search-controls.test.mjs tests/admin-editor-submit.browser.test.mjs`
