### PR TITLE
(fix): correct archive summary rail rendering

### DIFF
--- a/scripts/features/archive-page.js
+++ b/scripts/features/archive-page.js
@@ -106,6 +106,13 @@ export function createArchivePageFeature({
   function hydrateArchiveSummaryLinks(posts, publicState) {
     const hosts = [...document.querySelectorAll("[data-archive-summary]")];
     if (!hosts.length) return;
+    const markup = renderArchiveSummaryMarkup(posts, publicState);
+    for (const host of hosts) {
+      if (host instanceof HTMLElement) host.innerHTML = markup;
+    }
+  }
+
+  function renderArchiveSummaryMarkup(posts, publicState) {
     const publishedCount = Array.isArray(posts) ? posts.length : 0;
     const activeCount = investigationDrafts(publicState?.drafts || []).length;
     const investigationCount = publishedCount > 0 ? publishedCount : activeCount;
@@ -113,16 +120,13 @@ export function createArchivePageFeature({
     const entities = Array.isArray(publicState?.approvedEntities) ? publicState.approvedEntities : [];
     const mappedCount = entities.filter((entity) => Number.isFinite(entity.lat) && Number.isFinite(entity.lng)).length;
     const locationCount = dedupe(entities.map((entity) => String(entity.location || "").trim()).filter(Boolean)).length;
-    const tagCount = dedupe((Array.isArray(posts) ? posts : []).flatMap((post) => (Array.isArray(post?.tags) ? post.tags : [])));
-    const markup = `
+    const tagCount = dedupe((Array.isArray(posts) ? posts : []).flatMap((post) => (Array.isArray(post?.tags) ? post.tags : []))).length;
+    return `
       <a class="hero-summary__item" href="./investigations.html"><strong>${investigationCount}</strong><span>${investigationLabel}</span></a>
       <a class="hero-summary__item" href="./map.html#entity-index"><strong>${entities.length}</strong><span>Tracked entities</span></a>
       <a class="hero-summary__item" href="./map.html#map-board"><strong>${Math.max(mappedCount, locationCount)}</strong><span>Locations</span></a>
       <a class="hero-summary__item" href="./investigations.html"><strong>${tagCount}</strong><span>Archive tags</span></a>
     `;
-    for (const host of hosts) {
-      if (host instanceof HTMLElement) host.innerHTML = markup;
-    }
   }
 
   function buildPublishedArchiveEntries(posts) {
@@ -461,6 +465,7 @@ export function createArchivePageFeature({
     mount,
     isInteractionActive,
     hydrateArchiveSummaryLinks,
+    renderArchiveSummaryMarkup,
     renderInvestigationCard
   };
 }

--- a/styles/01-hero.css
+++ b/styles/01-hero.css
@@ -54,9 +54,13 @@
 }
 
 .hero-summary__item strong {
+  display: block;
   font-size: clamp(1.45rem, 3vw, 2rem);
   font-family: "Spectral", serif;
   color: inherit;
+  line-height: 0.95;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .hero-summary__item span {

--- a/tests/archive-summary.test.mjs
+++ b/tests/archive-summary.test.mjs
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createArchivePageFeature } from "../scripts/features/archive-page.js";
+
+test("archive summary tiles render numeric counts instead of joined tag strings", () => {
+  const feature = createArchivePageFeature({
+    state: {},
+    viewerController: { canEdit: () => false },
+    postsStore: { current: () => [], refresh: async () => [] },
+    getPublicState: async () => ({}),
+    publicStateNeedsRepair: () => false,
+    queueLeafletBoundsFit: () => {},
+    renderError: () => {},
+    renderLoadingState: () => ""
+  });
+
+  const markup = feature.renderArchiveSummaryMarkup(
+    [
+      { tags: ["placeholder", "case-file", "records-demo"] },
+      { tags: ["records-demo", "facilities", "archive-demo"] }
+    ],
+    {
+      approvedEntities: [
+        { location: "Phoenix, Arizona", lat: 33.45, lng: -112.07 },
+        { location: "Phoenix, Arizona" },
+        { location: "Tulare County, CA" }
+      ],
+      drafts: []
+    }
+  );
+
+  assert.match(markup, /<strong>5<\/strong><span>Archive tags<\/span>/);
+  assert.doesNotMatch(markup, /placeholder,case-file,records-demo/);
+});


### PR DESCRIPTION
## Summary
- fix the archive snapshot rail on `home` and `about` so the `Archive tags` tile renders a numeric count
- harden the stat-tile value styling to degrade cleanly if a long payload ever slips through again
- add a regression test for the shared archive summary renderer

## Testing
- `node --test (Get-ChildItem tests -Filter *.test.mjs | Select-Object -ExpandProperty FullName)`
- headless Playwright screenshot passes against local `home`, `investigations`, `investigation`, `about`, `get-involved`, `submit`, `map`, and `admin`

Closes #91
