### PR TITLE
(fix): restore shared card grid styling

### DIFF
--- a/styles/01-hero.css
+++ b/styles/01-hero.css
@@ -225,7 +225,3 @@
 .section__head p {
   max-width: 42rem;
 }
-
-.metric-grid,
-.card-grid,
-.info-grid,

--- a/styles/02-content.css
+++ b/styles/02-content.css
@@ -1,5 +1,8 @@
 /* Content, Archive, And Article Surfaces */
 
+.metric-grid,
+.card-grid,
+.info-grid,
 .article-grid,
 .support-grid,
 .form-layout,

--- a/tests/admin-editor-submit.browser.test.mjs
+++ b/tests/admin-editor-submit.browser.test.mjs
@@ -1,94 +1,16 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import http from "node:http";
-import fs from "node:fs/promises";
-import path from "node:path";
-import { pathToFileURL } from "node:url";
+
+import {
+  captureRelevantConsoleErrors,
+  createStaticServer,
+  loadPlaywright,
+  seedAdminSession
+} from "./browser-test-utils.mjs";
 
 const repoRoot = process.cwd();
-const port = 4173;
 const secretKeyHex = "1111111111111111111111111111111111111111111111111111111111111111";
 const pubkey = "4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa";
-
-function contentType(filePath) {
-  return {
-    ".html": "text/html; charset=utf-8",
-    ".js": "text/javascript; charset=utf-8",
-    ".css": "text/css; charset=utf-8",
-    ".json": "application/json; charset=utf-8",
-    ".svg": "image/svg+xml",
-    ".md": "text/markdown; charset=utf-8"
-  }[path.extname(filePath).toLowerCase()] || "application/octet-stream";
-}
-
-async function createStaticServer(root) {
-  const server = http.createServer(async (req, res) => {
-    try {
-      const urlPath = decodeURIComponent((req.url || "/").split("?")[0]);
-      const relativePath = urlPath === "/" ? "/index.html" : urlPath;
-      const filePath = path.join(root, relativePath);
-      const buffer = await fs.readFile(filePath);
-      res.writeHead(200, { "Content-Type": contentType(filePath) });
-      res.end(buffer);
-    } catch {
-      res.writeHead(404);
-      res.end("not found");
-    }
-  });
-  await new Promise((resolve) => server.listen(port, "127.0.0.1", resolve));
-  return server;
-}
-
-async function loadPlaywright() {
-  const playwrightPath = path.resolve(repoRoot, "../nostr-site/tooling/browser-smoke/node_modules/playwright/index.mjs");
-  try {
-    return await import(pathToFileURL(playwrightPath).href);
-  } catch {
-    return null;
-  }
-}
-
-function captureRelevantConsoleErrors(page, bucket) {
-  page.on("console", (msg) => {
-    if (msg.type() !== "error") return;
-    const text = msg.text();
-    if (
-      text.includes("renderSearchField") ||
-      text.includes("Node.removeChild") ||
-      text.includes("toastui") ||
-      text.includes("ReferenceError") ||
-      text.includes("TypeError") ||
-      text.includes("DOMException")
-    ) {
-      bucket.push(text);
-    }
-  });
-}
-
-async function seedSession(page) {
-  await page.goto(`http://127.0.0.1:${port}/index.html`, { waitUntil: "domcontentloaded" });
-  await page.evaluate(({ secretKeyHex, pubkey }) => {
-    localStorage.setItem(
-      "truecost.v2.session",
-      JSON.stringify({ username: "smoke-user", secretKeyHex, pubkey })
-    );
-    localStorage.setItem(
-      "truecost.v2.public-state-snapshot",
-      JSON.stringify({
-        admins: [pubkey],
-        users: [{ pubkey, username: "smoke-user", displayName: "Smoke User", socialLinks: [] }],
-        entities: [{ slug: "county-yard", name: "County Yard", location: "Phoenix, Arizona", status: "approved", type: "facility", notes: "" }],
-        approvedEntities: [{ slug: "county-yard", name: "County Yard", location: "Phoenix, Arizona", status: "approved", type: "facility", notes: "" }],
-        drafts: [],
-        allComments: [],
-        comments: [],
-        metrics: {},
-        rawEvents: [{ id: "cached:1", kind: 0 }],
-        syncInfo: { connected: false, remoteEventCount: 0, cachedEventCount: 1, mergedEventCount: 1 }
-      })
-    );
-  }, { secretKeyHex, pubkey });
-}
 
 test("admin workspace, submit autocomplete, and editor boot survive cached admin load", async (t) => {
   const playwright = await loadPlaywright();
@@ -97,7 +19,7 @@ test("admin workspace, submit autocomplete, and editor boot survive cached admin
     return;
   }
 
-  const server = await createStaticServer(repoRoot);
+  const { server, port } = await createStaticServer(repoRoot);
   const browser = await playwright.chromium.launch({ headless: true });
   const context = await browser.newContext();
   const page = await context.newPage();
@@ -108,7 +30,7 @@ test("admin workspace, submit autocomplete, and editor boot survive cached admin
   captureRelevantConsoleErrors(page, consoleErrors);
 
   try {
-    await seedSession(page);
+    await seedAdminSession(page, { port, secretKeyHex, pubkey });
 
     await page.goto(`http://127.0.0.1:${port}/admin.html`, { waitUntil: "domcontentloaded" });
     await page.waitForSelector("[data-workspace-pane]", { timeout: 15000 });
@@ -163,7 +85,7 @@ test("admin workspace, submit autocomplete, and editor boot survive cached admin
       { timeout: 5000 }
     );
 
-    await seedSession(page);
+    await seedAdminSession(page, { port, secretKeyHex, pubkey });
     await page.goto(`http://127.0.0.1:${port}/editor.html`, { waitUntil: "domcontentloaded" });
     await page.waitForSelector("[data-editor-form]", { timeout: 15000 });
     await page.waitForTimeout(2000);

--- a/tests/browser-test-utils.mjs
+++ b/tests/browser-test-utils.mjs
@@ -1,0 +1,88 @@
+import http from "node:http";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export function contentType(filePath) {
+  return {
+    ".html": "text/html; charset=utf-8",
+    ".js": "text/javascript; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".json": "application/json; charset=utf-8",
+    ".svg": "image/svg+xml",
+    ".md": "text/markdown; charset=utf-8"
+  }[path.extname(filePath).toLowerCase()] || "application/octet-stream";
+}
+
+export async function createStaticServer(root, port = 0) {
+  const server = http.createServer(async (req, res) => {
+    try {
+      const urlPath = decodeURIComponent((req.url || "/").split("?")[0]);
+      const relativePath = urlPath === "/" ? "/index.html" : urlPath;
+      const filePath = path.join(root, relativePath);
+      const buffer = await fs.readFile(filePath);
+      res.writeHead(200, { "Content-Type": contentType(filePath) });
+      res.end(buffer);
+    } catch {
+      res.writeHead(404);
+      res.end("not found");
+    }
+  });
+  await new Promise((resolve) => server.listen(port, "127.0.0.1", resolve));
+  const address = server.address();
+  return {
+    server,
+    port: typeof address === "object" && address ? address.port : port
+  };
+}
+
+export async function loadPlaywright(repoRoot = process.cwd()) {
+  const playwrightPath = path.resolve(repoRoot, "../nostr-site/tooling/browser-smoke/node_modules/playwright/index.mjs");
+  try {
+    return await import(pathToFileURL(playwrightPath).href);
+  } catch {
+    return null;
+  }
+}
+
+export function captureRelevantConsoleErrors(page, bucket) {
+  page.on("console", (msg) => {
+    if (msg.type() !== "error") return;
+    const text = msg.text();
+    if (
+      text.includes("renderSearchField") ||
+      text.includes("Node.removeChild") ||
+      text.includes("toastui") ||
+      text.includes("ReferenceError") ||
+      text.includes("TypeError") ||
+      text.includes("DOMException")
+    ) {
+      bucket.push(text);
+    }
+  });
+}
+
+export async function seedAdminSession(page, { port, secretKeyHex, pubkey }) {
+  await page.goto(`http://127.0.0.1:${port}/index.html`, { waitUntil: "domcontentloaded" });
+  await page.evaluate(({ secretKeyHex: nextSecretKeyHex, pubkey: nextPubkey }) => {
+    localStorage.setItem(
+      "truecost.v2.session",
+      JSON.stringify({ username: "smoke-user", secretKeyHex: nextSecretKeyHex, pubkey: nextPubkey })
+    );
+    localStorage.setItem(
+      "truecost.v2.public-state-snapshot",
+      JSON.stringify({
+        admins: [nextPubkey],
+        users: [{ pubkey: nextPubkey, username: "smoke-user", displayName: "Smoke User", socialLinks: [] }],
+        entities: [{ slug: "county-yard", name: "County Yard", location: "Phoenix, Arizona", status: "approved", type: "facility", notes: "" }],
+        approvedEntities: [{ slug: "county-yard", name: "County Yard", location: "Phoenix, Arizona", status: "approved", type: "facility", notes: "" }],
+        drafts: [],
+        allComments: [],
+        comments: [],
+        metrics: {},
+        rawEvents: [{ id: "cached:1", kind: 0 }],
+        syncInfo: { connected: false, remoteEventCount: 0, cachedEventCount: 1, mergedEventCount: 1 }
+      })
+    );
+  }, { secretKeyHex, pubkey });
+}

--- a/tests/page-style-smoke.browser.test.mjs
+++ b/tests/page-style-smoke.browser.test.mjs
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createStaticServer,
+  loadPlaywright,
+  seedAdminSession
+} from "./browser-test-utils.mjs";
+
+const repoRoot = process.cwd();
+const secretKeyHex = "1111111111111111111111111111111111111111111111111111111111111111";
+const pubkey = "4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa";
+
+test("desktop public and workspace pages keep shared card layouts after stylesheet changes", async (t) => {
+  const playwright = await loadPlaywright();
+  if (!playwright?.chromium) {
+    t.skip("Playwright is not available in this workspace.");
+    return;
+  }
+
+  const { server, port } = await createStaticServer(repoRoot);
+  const browser = await playwright.chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1440, height: 1600 } });
+  const page = await context.newPage();
+
+  try {
+    await page.goto(`http://127.0.0.1:${port}/index.html`, { waitUntil: "networkidle" });
+    await page.waitForTimeout(1200);
+    const homeMetrics = await page.evaluate(() => {
+      const grid = document.querySelector("[data-home-investigations]");
+      const gridRect = grid?.getBoundingClientRect();
+      const cards = Array.from(grid?.children || []).slice(0, 2).map((node) => {
+        const rect = node.getBoundingClientRect();
+        return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+      });
+      const style = grid ? getComputedStyle(grid) : null;
+      return {
+        display: style?.display || "",
+        columns: style?.gridTemplateColumns || "",
+        gridWidth: gridRect?.width || 0,
+        cards
+      };
+    });
+
+    assert.equal(homeMetrics.display, "grid");
+    assert.ok(homeMetrics.columns.includes("px"), "home investigations should resolve desktop grid columns");
+    assert.ok(homeMetrics.cards.length >= 1, "featured investigations should render at least one card");
+    assert.ok(
+      homeMetrics.cards[0].width < homeMetrics.gridWidth * 0.75,
+      "desktop featured cards should not collapse into a single full-width column"
+    );
+
+    await seedAdminSession(page, { port, secretKeyHex, pubkey });
+    await page.goto(`http://127.0.0.1:${port}/admin.html?tab=dashboard`, { waitUntil: "networkidle" });
+    await page.waitForSelector("[data-workspace-pane]", { timeout: 15000 });
+    await page.waitForFunction(
+      () =>
+        document.querySelector(".workspace-tab.is-current")?.textContent?.includes("Dashboard") &&
+        document.querySelectorAll(".metric-card").length > 0,
+      { timeout: 15000 }
+    );
+    const adminMetrics = await page.evaluate(() => {
+      const statCard = document.querySelector(".workspace-grid .metric-card");
+      const snapshotCard = document.querySelector("[data-request-snapshot]")?.closest(".surface-panel");
+      if (!(statCard instanceof HTMLElement) || !(snapshotCard instanceof HTMLElement)) return null;
+      const statStyle = getComputedStyle(statCard);
+      const snapshotStyle = getComputedStyle(snapshotCard);
+      return {
+        statPaddingTop: statStyle.paddingTop,
+        statPaddingLeft: statStyle.paddingLeft,
+        snapshotPaddingTop: snapshotStyle.paddingTop,
+        snapshotPaddingLeft: snapshotStyle.paddingLeft
+      };
+    });
+
+    assert.ok(adminMetrics, "workspace cards should exist");
+    assert.notEqual(adminMetrics.statPaddingTop, "0px", "workspace metric cards should keep internal padding");
+    assert.notEqual(adminMetrics.statPaddingLeft, "0px", "workspace metric cards should keep internal padding");
+    assert.notEqual(adminMetrics.snapshotPaddingTop, "0px", "workspace surface panels should keep internal padding");
+    assert.notEqual(adminMetrics.snapshotPaddingLeft, "0px", "workspace surface panels should keep internal padding");
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});


### PR DESCRIPTION
Summary
- restore the shared card/grid baseline after the stylesheet split
- fix the broken shared desktop card layout on home and related surfaces
- add browser coverage for shared layout regressions with a reusable local harness

Testing
- node --test tests/archive-summary.test.mjs tests/admin-editor-submit.browser.test.mjs tests/page-style-smoke.browser.test.mjs

Closes #93